### PR TITLE
Update crate metadata to prepare for publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "virtio-drivers"
-version = "0.9.0"
+name = "virtio-drivers-and-devices"
+version = "0.1.0"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",
@@ -9,8 +9,8 @@ authors = [
   "Andrew Walbran <qwandor@google.com>",
 ]
 edition = "2021"
-description = "VirtIO guest drivers."
-repository = "https://github.com/rcore-os/virtio-drivers"
+description = "VirtIO guest drivers and devices. Fork of rcore-os/virtio-drivers."
+repository = "https://github.com/immunant/virtio-drivers-and-devices"
 keywords = ["virtio"]
 categories = ["hardware-support", "no-std"]
 

--- a/README.md
+++ b/README.md
@@ -1,71 +1,7 @@
-# VirtIO-drivers-rs
+# VirtIO-drivers-and-devices
 
-[![crates.io page](https://img.shields.io/crates/v/virtio-drivers.svg)](https://crates.io/crates/virtio-drivers)
-[![docs.rs page](https://docs.rs/virtio-drivers/badge.svg)](https://docs.rs/virtio-drivers)
-[![CI](https://github.com/rcore-os/virtio-drivers/workflows/CI/badge.svg?branch=master)](https://github.com/rcore-os/virtio-drivers/actions)
+[![crates.io page](https://img.shields.io/crates/v/virtio-drivers.svg)](https://crates.io/crates/virtio-drivers-and-devices)
 
-VirtIO guest drivers in Rust. For **no_std** environment.
+VirtIO guest drivers and devices in Rust. For **no_std** environment.
+Fork of https://github.com/rcore-os/virtio-drivers.
 
-## Support status
-
-### Device types
-
-| Device  | Supported |
-| ------- | --------- |
-| Block   | ✅        |
-| Net     | ✅        |
-| GPU     | ✅        |
-| Input   | ✅        |
-| Console | ✅        |
-| Socket  | ✅        |
-| Sound   | ✅        |
-| ...     | ❌        |
-
-### Transports
-
-| Transport   | Supported |                                                   |
-| ----------- | --------- | ------------------------------------------------- |
-| Legacy MMIO | ✅        | version 1                                         |
-| MMIO        | ✅        | version 2                                         |
-| PCI         | ✅        | Memory-mapped CAM only, e.g. aarch64 or PCIe ECAM |
-
-### Device-independent features
-
-| Feature flag                 | Supported |                                         |
-| ---------------------------- | --------- | --------------------------------------- |
-| `VIRTIO_F_INDIRECT_DESC`     | ✅        | Indirect descriptors                    |
-| `VIRTIO_F_EVENT_IDX`         | ✅        | `avail_event` and `used_event` fields   |
-| `VIRTIO_F_VERSION_1`         | TODO      | VirtIO version 1 compliance             |
-| `VIRTIO_F_ACCESS_PLATFORM`   | ❌        | Limited device access to memory         |
-| `VIRTIO_F_RING_PACKED`       | ❌        | Packed virtqueue layout                 |
-| `VIRTIO_F_IN_ORDER`          | ❌        | Optimisations for in-order buffer usage |
-| `VIRTIO_F_ORDER_PLATFORM`    | ❌        | Platform ordering for memory access     |
-| `VIRTIO_F_SR_IOV`            | ❌        | Single root I/O virtualization          |
-| `VIRTIO_F_NOTIFICATION_DATA` | ❌        | Extra data in device notifications      |
-
-## Examples & Tests
-
-### [x86_64](./examples/x86_64)
-
-```bash
-cd examples/x86_64
-make qemu
-```
-
-### [aarch64](./examples/aarch64)
-
-```bash
-cd examples/aarch64
-make qemu
-```
-
-### [RISCV](./examples/riscv)
-
-```bash
-cd examples/riscv
-make qemu
-```
-
-You will see device info & GUI Window in qemu.
-
-<img decoding="async" src="https://github.com/rcore-os/virtio-drivers/raw/master/examples/riscv/virtio-test-gpu.png" width="50%">


### PR DESCRIPTION
Mark it as fork of rcore-os/virtio-drivers. Update crate URL.