### PR TITLE
Add support for vsock devices and VsockManager trait

### DIFF
--- a/examples/aarch64/Cargo.toml
+++ b/examples/aarch64/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4.22"
 pl011-uart = "0.1.0"
 smccc = "0.1.1"
 spin = "0.9.8"
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/examples/aarch64/src/hal.rs
+++ b/examples/aarch64/src/hal.rs
@@ -1,7 +1,7 @@
 use alloc::alloc::{alloc_zeroed, dealloc, handle_alloc_error};
 use core::{alloc::Layout, ptr::NonNull};
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 pub struct HalImpl;
 

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -23,7 +23,7 @@ use flat_device_tree::{node::FdtNode, standard_nodes::Compatible, Fdt};
 use hal::HalImpl;
 use log::{debug, error, info, trace, warn, LevelFilter};
 use smccc::{psci::system_off, Hvc};
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{
         blk::VirtIOBlk,
         console::VirtIOConsole,
@@ -218,7 +218,7 @@ fn virtio_console<T: Transport>(transport: T) {
     info!("virtio-console test finished");
 }
 
-fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers::Result<()> {
+fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers_and_devices::Result<()> {
     let mut socket = VsockConnectionManager::new(
         VirtIOSocket::<HalImpl, T>::new(transport).expect("Failed to create socket driver"),
     );

--- a/examples/riscv/Cargo.toml
+++ b/examples/riscv/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 riscv = "0.10"
 opensbi-rt = { git = "https://github.com/rcore-os/opensbi-rt.git", rev = "abdfeb72" }
 flat_device_tree = "3.1.1"
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 
 [dependencies.smoltcp]

--- a/examples/riscv/src/main.rs
+++ b/examples/riscv/src/main.rs
@@ -12,7 +12,7 @@ use alloc::vec;
 use core::ptr::NonNull;
 use flat_device_tree::{node::FdtNode, standard_nodes::Compatible, Fdt};
 use log::LevelFilter;
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{
         blk::VirtIOBlk,
         gpu::VirtIOGpu,
@@ -153,9 +153,12 @@ fn virtio_input<T: Transport>(transport: T) {
 fn virtio_net<T: Transport>(transport: T) {
     #[cfg(not(feature = "tcp"))]
     {
-        let mut net =
-            virtio_drivers::device::net::VirtIONetRaw::<HalImpl, T, NET_QUEUE_SIZE>::new(transport)
-                .expect("failed to create net driver");
+        let mut net = virtio_drivers_and_devices::device::net::VirtIONetRaw::<
+            HalImpl,
+            T,
+            NET_QUEUE_SIZE,
+        >::new(transport)
+        .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
 
         let mut buf = [0u8; 2048];
@@ -172,11 +175,12 @@ fn virtio_net<T: Transport>(transport: T) {
     #[cfg(feature = "tcp")]
     {
         const NET_BUFFER_LEN: usize = 2048;
-        let net = virtio_drivers::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
-            transport,
-            NET_BUFFER_LEN,
-        )
-        .expect("failed to create net driver");
+        let net =
+            virtio_drivers_and_devices::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
+                transport,
+                NET_BUFFER_LEN,
+            )
+            .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
         tcp::test_echo_server(net);
     }

--- a/examples/riscv/src/tcp.rs
+++ b/examples/riscv/src/tcp.rs
@@ -9,8 +9,8 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 use smoltcp::{socket::tcp, time::Instant};
-use virtio_drivers::device::net::{RxBuffer, VirtIONet};
-use virtio_drivers::{transport::Transport, Error};
+use virtio_drivers_and_devices::device::net::{RxBuffer, VirtIONet};
+use virtio_drivers_and_devices::{transport::Transport, Error};
 
 use super::{HalImpl, NET_QUEUE_SIZE};
 

--- a/examples/riscv/src/virtio_impl.rs
+++ b/examples/riscv/src/virtio_impl.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     fn end();

--- a/examples/x86_64/Cargo.toml
+++ b/examples/x86_64/Cargo.toml
@@ -18,7 +18,7 @@ x86_64 = { version = "0.14.12", default-features = false, features = [
 uart_16550 = "0.2"
 linked_list_allocator = "0.10"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
-virtio-drivers = { path = "../.." }
+virtio-drivers-and-devices = { path = "../.." }
 
 [dependencies.smoltcp]
 version = "0.9.1"

--- a/examples/x86_64/src/hal.rs
+++ b/examples/x86_64/src/hal.rs
@@ -4,7 +4,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log::trace;
-use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+use virtio_drivers_and_devices::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 
 extern "C" {
     static dma_region: u8;

--- a/examples/x86_64/src/main.rs
+++ b/examples/x86_64/src/main.rs
@@ -17,7 +17,7 @@ mod trap;
 mod tcp;
 
 use self::hal::HalImpl;
-use virtio_drivers::{
+use virtio_drivers_and_devices::{
     device::{blk::VirtIOBlk, gpu::VirtIOGpu},
     transport::{
         pci::{
@@ -118,9 +118,12 @@ fn virtio_gpu<T: Transport>(transport: T) {
 fn virtio_net<T: Transport>(transport: T) {
     #[cfg(not(feature = "tcp"))]
     {
-        let mut net =
-            virtio_drivers::device::net::VirtIONetRaw::<HalImpl, T, NET_QUEUE_SIZE>::new(transport)
-                .expect("failed to create net driver");
+        let mut net = virtio_drivers_and_devices::device::net::VirtIONetRaw::<
+            HalImpl,
+            T,
+            NET_QUEUE_SIZE,
+        >::new(transport)
+        .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
 
         let mut buf = [0u8; 2048];
@@ -137,11 +140,12 @@ fn virtio_net<T: Transport>(transport: T) {
     #[cfg(feature = "tcp")]
     {
         const NET_BUFFER_LEN: usize = 2048;
-        let net = virtio_drivers::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
-            transport,
-            NET_BUFFER_LEN,
-        )
-        .expect("failed to create net driver");
+        let net =
+            virtio_drivers_and_devices::device::net::VirtIONet::<HalImpl, T, NET_QUEUE_SIZE>::new(
+                transport,
+                NET_BUFFER_LEN,
+            )
+            .expect("failed to create net driver");
         info!("MAC address: {:02x?}", net.mac_address());
         tcp::test_echo_server(net);
     }

--- a/examples/x86_64/src/tcp.rs
+++ b/examples/x86_64/src/tcp.rs
@@ -9,8 +9,8 @@ use smoltcp::iface::{Config, Interface, SocketSet};
 use smoltcp::phy::{Device, DeviceCapabilities, Medium, RxToken, TxToken};
 use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr, Ipv4Address};
 use smoltcp::{socket::tcp, time::Instant};
-use virtio_drivers::device::net::{RxBuffer, VirtIONet};
-use virtio_drivers::{transport::Transport, Error};
+use virtio_drivers_and_devices::device::net::{RxBuffer, VirtIONet};
+use virtio_drivers_and_devices::{transport::Transport, Error};
 
 use super::{HalImpl, NET_QUEUE_SIZE};
 

--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -26,9 +26,9 @@ const SUPPORTED_FEATURES: BlkFeature = BlkFeature::RO
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal};
-/// # use virtio_drivers::transport::Transport;
-/// use virtio_drivers::device::blk::{VirtIOBlk, SECTOR_SIZE};
+/// # use virtio_drivers_and_devices::{Error, Hal};
+/// # use virtio_drivers_and_devices::transport::Transport;
+/// use virtio_drivers_and_devices::device::blk::{VirtIOBlk, SECTOR_SIZE};
 ///
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut disk = VirtIOBlk::<HalImpl, _>::new(transport)?;
@@ -212,10 +212,10 @@ impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// the same buffers before reading the response.
     ///
     /// ```
-    /// # use virtio_drivers::{Error, Hal};
-    /// # use virtio_drivers::device::blk::VirtIOBlk;
-    /// # use virtio_drivers::transport::Transport;
-    /// use virtio_drivers::device::blk::{BlkReq, BlkResp, RespStatus};
+    /// # use virtio_drivers_and_devices::{Error, Hal};
+    /// # use virtio_drivers_and_devices::device::blk::VirtIOBlk;
+    /// # use virtio_drivers_and_devices::transport::Transport;
+    /// use virtio_drivers_and_devices::device::blk::{BlkReq, BlkResp, RespStatus};
     ///
     /// # fn example<H: Hal, T: Transport>(blk: &mut VirtIOBlk<H, T>) -> Result<(), Error> {
     /// let mut request = BlkReq::default();

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -29,8 +29,8 @@ const SUPPORTED_FEATURES: Features = Features::RING_EVENT_IDX
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal, transport::Transport};
-/// use virtio_drivers::device::console::VirtIOConsole;
+/// # use virtio_drivers_and_devices::{Error, Hal, transport::Transport};
+/// use virtio_drivers_and_devices::device::console::VirtIOConsole;
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut console = VirtIOConsole::<HalImpl, _>::new(transport)?;
 ///

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -1,7 +1,7 @@
 //! Driver for VirtIO GPU devices.
 
 use crate::config::{read_config, ReadOnly, WriteOnly};
-use crate::hal::{BufferDirection, Dma, Hal};
+use crate::hal::{BufferDirection, Dma, DmaMemory, Hal};
 use crate::queue::VirtQueue;
 use crate::transport::Transport;
 use crate::{pages, Error, Result, PAGE_SIZE};

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -25,9 +25,9 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers::{Error, Hal};
-/// # use virtio_drivers::transport::Transport;
-/// use virtio_drivers::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
+/// # use virtio_drivers_and_devices::{Error, Hal};
+/// # use virtio_drivers_and_devices::transport::Transport;
+/// use virtio_drivers_and_devices::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
 ///
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
 /// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _>::new(transport)?);

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -15,7 +15,7 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager};
+pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager, VsockManager};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -21,6 +21,9 @@ pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]
 pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
 
+#[cfg(feature = "alloc")]
+pub(crate) use vsock::VirtIOSocketManager;
+
 /// The size in bytes of each buffer used in the RX virtqueue. This must be bigger than
 /// `size_of::<VirtioVsockHdr>()`.
 const DEFAULT_RX_BUFFER_SIZE: usize = 512;

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -19,7 +19,9 @@ pub use connectionmanager::VsockConnectionManager;
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]
-pub use vsock::{ConnectionInfo, DisconnectReason, VirtIOSocket, VsockEvent, VsockEventType};
+pub use vsock::{
+    ConnectionInfo, DisconnectReason, VirtIOSocket, VirtIOSocketDevice, VsockEvent, VsockEventType,
+};
 
 #[cfg(feature = "alloc")]
 pub(crate) use vsock::VirtIOSocketManager;

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -15,7 +15,7 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::VsockConnectionManager;
+pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -405,6 +405,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
     }
 }
 
+/// A low-level interface for a vsock device implementation
 pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport> {
     transport: T,
     rx: DeviceVirtQueue<H, { QUEUE_SIZE }>,
@@ -413,6 +414,7 @@ pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport> {
 }
 
 impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketDevice<H, T> {
+    /// Create a new VirtIO Vsock device.
     pub fn new(mut transport: T) -> Result<Self> {
         let rx = DeviceVirtQueue::new(&mut transport, RX_QUEUE_IDX)?;
         let tx = DeviceVirtQueue::new(&mut transport, TX_QUEUE_IDX)?;

--- a/src/hal.rs
+++ b/src/hal.rs
@@ -140,6 +140,15 @@ pub unsafe trait Hal {
     unsafe fn unshare(paddr: PhysAddr, buffer: NonNull<[u8]>, direction: BufferDirection);
 }
 
+// TODO: document safety requirements
+/// Device-side abstraction layer for mapping and unmapping memory shared by the driver.
+pub trait DeviceHal {
+    /// Maps in memory shared by the driver.
+    unsafe fn dma_map(paddr: PhysAddr, pages: usize, direction: BufferDirection) -> Result<NonNull<u8>>;
+    /// Unmaps in memory previously shared by the driver.
+    unsafe fn dma_unmap(paddr: PhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32;
+}
+
 /// The direction in which a buffer is passed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BufferDirection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ use core::ptr::{self, NonNull};
 use device::socket::SocketError;
 use thiserror::Error;
 
-pub use self::hal::{BufferDirection, Hal, PhysAddr};
+pub use self::hal::{BufferDirection, DeviceHal, Hal, PhysAddr};
 
 /// The page size in bytes supported by the library (4 KiB).
 pub const PAGE_SIZE: usize = 0x1000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```
 //! use core::ptr::NonNull;
-//! use virtio_drivers::transport::mmio::{MmioTransport, VirtIOHeader};
+//! use virtio_drivers_and_devices::transport::mmio::{MmioTransport, VirtIOHeader};
 //!
 //! # fn example(mmio_device_address: usize, mmio_size: usize) {
 //! let header = NonNull::new(mmio_device_address as *mut VirtIOHeader).unwrap();
@@ -23,9 +23,9 @@
 //! You can then check what kind of VirtIO device it is and construct the appropriate driver:
 //!
 //! ```
-//! # use virtio_drivers::Hal;
+//! # use virtio_drivers_and_devices::Hal;
 //! # #[cfg(feature = "alloc")]
-//! use virtio_drivers::{
+//! use virtio_drivers_and_devices::{
 //!     device::console::VirtIOConsole,
 //!     transport::{mmio::MmioTransport, DeviceType, Transport},
 //! };

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "alloc")]
 pub mod owning;
 
-use crate::hal::{BufferDirection, Dma, Hal, PhysAddr};
+use crate::hal::{BufferDirection, Dma, DmaMemory, Hal, PhysAddr};
 use crate::transport::Transport;
 use crate::{align_up, nonnull_slice_from_raw_parts, pages, Error, Result, PAGE_SIZE};
 #[cfg(feature = "alloc")]

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -732,6 +732,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
     ///
     /// The caller must ensure that the returned buffers are not accessed after the first buffer's
     /// token has been written to the used vring and the `last_used` index has been updated.
+    #[cfg(feature = "alloc")]
     unsafe fn pop_avail<'a>(&mut self) -> Result<Option<(Vec<&'a mut [u8]>, u16)>> {
         let Some(head) = self.peek_avail() else {
             return Ok(None);

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,6 +17,9 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// A VirtIO device-side transport layer.
 pub trait DeviceTransport {
+    /// Gets the client VM ID
+    fn get_client_id(&self) -> u16;
+
     /// Gets the max size of the given queue.
     fn max_queue_size(&mut self, queue: u16) -> u32;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -15,6 +15,23 @@ use log::debug;
 pub use some::SomeTransport;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
+/// A VirtIO device-side transport layer.
+pub trait DeviceTransport {
+    /// Gets the max size of the given queue.
+    fn max_queue_size(&mut self, queue: u16) -> u32;
+
+    /// Returns whether the transport requires queues to use the legacy layout.
+    ///
+    /// Ref: 2.6.2 Legacy Interfaces: A Note on Virtqueue Layout
+    fn requires_legacy_layout(&self) -> bool;
+
+    /// Gets the physical addresses for descriptors, driver area and device area for a given queue.
+    fn queue_get(&mut self, queue: u16) -> [PhysAddr; 3];
+
+    /// Notifies the given queue on the device.
+    fn notify(&mut self, queue: u16);
+}
+
 /// A VirtIO transport layer.
 pub trait Transport {
     /// Gets the device type.

--- a/src/volatile.rs
+++ b/src/volatile.rs
@@ -68,7 +68,7 @@ impl<T: Copy> VolatileWritable<T> for *mut Volatile<T> {
 /// # Usage
 /// ```compile_fail
 /// # use core::ptr::NonNull;
-/// # use virtio_drivers::volatile::{ReadOnly, volread};
+/// # use virtio_drivers_and_devices::volatile::{ReadOnly, volread};
 /// struct MmioDevice {
 ///   field: ReadOnly<u32>,
 /// }
@@ -87,7 +87,7 @@ macro_rules! volread {
 /// # Usage
 /// ```compile_fail
 /// # use core::ptr::NonNull;
-/// # use virtio_drivers::volatile::{WriteOnly, volread};
+/// # use virtio_drivers_and_devices::volatile::{WriteOnly, volread};
 /// struct MmioDevice {
 ///   field: WriteOnly<u32>,
 /// }


### PR DESCRIPTION
This PR adds support for vsock devices and the VsockManager trait to allow defining functions that are generic over whether the vsock connection is managed by a driver or device. See individual commit messages for more details.