### PR TITLE
Support bus addresses in device virtqueues

### DIFF
--- a/src/hal.rs
+++ b/src/hal.rs
@@ -2,6 +2,7 @@
 pub mod fake;
 
 use crate::{Error, Result, PAGE_SIZE};
+use core::cmp::PartialEq;
 use core::{marker::PhantomData, ptr::NonNull};
 
 /// A physical address as used for virtio.
@@ -92,6 +93,15 @@ unsafe impl<H: DeviceHal> Send for DeviceDma<H> {}
 // SAFETY: `&DeviceDma` only allows pointers and physical addresses to be returned. Any accesses to
 // the memory requires unsafe code, which is responsible for avoiding data races.
 unsafe impl<H: DeviceHal> Sync for DeviceDma<H> {}
+
+impl<H: DeviceHal> PartialEq for DeviceDma<H> {
+    fn eq(&self, other: &Self) -> bool {
+        let paddrs_match = self.paddr == other.paddr;
+        let vaddrs_match = self.vaddr == other.vaddr;
+        let num_pages_match = self.pages == other.pages;
+        paddrs_match && vaddrs_match && num_pages_match
+    }
+}
 
 impl<H: DeviceHal> DeviceDma<H> {
     // SAFETY: The caller must ensure that the memory described by paddr and pages can be mapped by


### PR DESCRIPTION
If VIRTIO_F_ACCESS_PLATFORM is negotiated addresses in the virtqueues may be
"bus addresses" which get translated to physical addresses. When mapping in new
descriptor buffers we previously checked if the descriptor itself changed to
decide if we needed to unmap the old descriptor buffer (i.e. by implicitly
calling MappedDescriptor's Drop impl when replacing the stored MappedDescriptor
with the new one). Comparing the descriptor fields doesn't work if its address
field is a bus address because the same bus address may be translated to
different physical addresses at different times (e.g. a virtio-msg area unshare
followed by an area share reusing the same bus address) so the descriptor may
refer to different buffers even though its value hasn't changed. This commit
changes the comparison to use virtual addresses instead to properly the case
where the descriptor address field is a bus address.