### PR TITLE
Prepare for 0.2.2 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtio-drivers-and-devices"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 authors = [
   "Jiajie Chen <noc@jiegec.ac.cn>",


### PR DESCRIPTION
Added support for  bus addresses in device virtqueues (https://github.com/immunant/virtio-drivers-and-devices/pull/11)