### PR TITLE
Handle failed feature negotiation correctly

### DIFF
--- a/src/device/blk.rs
+++ b/src/device/blk.rs
@@ -53,7 +53,7 @@ pub struct VirtIOBlk<H: Hal, T: Transport> {
 impl<H: Hal, T: Transport> VirtIOBlk<H, T> {
     /// Create a new VirtIO-Blk driver.
     pub fn new(mut transport: T) -> Result<Self> {
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
 
         // Read configuration space.
         let capacity = transport.read_consistent(|| {

--- a/src/device/console.rs
+++ b/src/device/console.rs
@@ -91,7 +91,7 @@ impl Display for Size {
 impl<H: Hal, T: Transport> VirtIOConsole<H, T> {
     /// Creates a new VirtIO console driver.
     pub fn new(mut transport: T) -> Result<Self> {
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
         let receiveq = VirtQueue::new(
             &mut transport,
             QUEUE_RECEIVEQ_PORT_0,

--- a/src/device/gpu.rs
+++ b/src/device/gpu.rs
@@ -42,7 +42,7 @@ pub struct VirtIOGpu<H: Hal, T: Transport> {
 impl<H: Hal, T: Transport> VirtIOGpu<H, T> {
     /// Create a new VirtIO-Gpu driver.
     pub fn new(mut transport: T) -> Result<Self> {
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
 
         // read configuration space
         let events_read = read_config!(transport, Config, events_read)?;

--- a/src/device/input.rs
+++ b/src/device/input.rs
@@ -28,7 +28,7 @@ impl<H: Hal, T: Transport> VirtIOInput<H, T> {
     pub fn new(mut transport: T) -> Result<Self, Error> {
         let mut event_buf = Box::new([InputEvent::default(); QUEUE_SIZE]);
 
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
 
         let mut event_queue = VirtQueue::new(
             &mut transport,

--- a/src/device/net/dev_raw.rs
+++ b/src/device/net/dev_raw.rs
@@ -29,7 +29,7 @@ pub struct VirtIONetRaw<H: Hal, T: Transport, const QUEUE_SIZE: usize> {
 impl<H: Hal, T: Transport, const QUEUE_SIZE: usize> VirtIONetRaw<H, T, QUEUE_SIZE> {
     /// Create a new VirtIO-Net driver.
     pub fn new(mut transport: T) -> Result<Self> {
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
         info!("negotiated_features {:?}", negotiated_features);
 
         // Read configuration space.

--- a/src/device/rng.rs
+++ b/src/device/rng.rs
@@ -22,7 +22,7 @@ pub struct VirtIORng<H: Hal, T: Transport> {
 impl<H: Hal, T: Transport> VirtIORng<H, T> {
     /// Create a new driver with the given transport.
     pub fn new(mut transport: T) -> Result<Self> {
-        let feat = transport.begin_init(SUPPORTED_FEATURES);
+        let feat = transport.begin_init(SUPPORTED_FEATURES)?;
         let queue = VirtQueue::new(
             &mut transport,
             QUEUE_IDX,

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -249,7 +249,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     pub fn new(mut transport: T) -> Result<Self> {
         assert!(RX_BUFFER_SIZE > size_of::<VirtioVsockHdr>());
 
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
 
         let guest_cid = transport.read_consistent(|| {
             Ok(

--- a/src/device/sound.rs
+++ b/src/device/sound.rs
@@ -64,7 +64,7 @@ pub struct VirtIOSound<H: Hal, T: Transport> {
 impl<H: Hal, T: Transport> VirtIOSound<H, T> {
     /// Create a new VirtIO-Sound driver.
     pub fn new(mut transport: T) -> Result<Self> {
-        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES);
+        let negotiated_features = transport.begin_init(SUPPORTED_FEATURES)?;
         info!(
             "[sound device] negotiated_features: {:?}",
             negotiated_features

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -8,7 +8,7 @@ mod some;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
-use crate::{PhysAddr, Result, PAGE_SIZE};
+use crate::{Error, PhysAddr, Result, PAGE_SIZE};
 use bitflags::{bitflags, Flags};
 use core::{fmt::Debug, ops::BitAnd};
 use log::debug;
@@ -57,6 +57,17 @@ pub trait Transport {
 
     /// Sets the device status.
     fn set_status(&mut self, status: DeviceStatus);
+
+    /// Sets the device status and allows optionally returning an error and the real device status.
+    ///
+    /// This is provided to allow transports to report errors encountered while trying to set the
+    /// status. The return value is the actual device status which may oy may not be the same as the
+    /// argument. Transports which do not provide the device status as the result of a set status
+    /// operation (such as PCI and MMIO) will return `None`.
+    fn try_set_status(&mut self, status: DeviceStatus) -> Result<Option<DeviceStatus>> {
+        self.set_status(status);
+        Ok(None)
+    }
 
     /// Sets the guest page size.
     fn set_guest_page_size(&mut self, guest_page_size: u32);
@@ -107,7 +118,7 @@ pub trait Transport {
     fn begin_init<F: Flags<Bits = u64> + BitAnd<Output = F> + Debug>(
         &mut self,
         supported_features: F,
-    ) -> F {
+    ) -> Result<F> {
         self.set_status(DeviceStatus::empty());
         self.set_status(DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER);
 
@@ -126,13 +137,23 @@ pub trait Transport {
         }
         self.write_driver_features(negotiated_features.bits());
 
-        self.set_status(
+        let set_status_resp = self.try_set_status(
             DeviceStatus::ACKNOWLEDGE | DeviceStatus::DRIVER | DeviceStatus::FEATURES_OK,
-        );
+        )?;
+
+        // If the device did not return the status as a response to set status, do an explicit get
+        // status call.
+        let device_status = set_status_resp.unwrap_or(self.get_status());
+
+        // If the device ignored the FEATURES_OK bit bail out.
+        if !device_status.contains(DeviceStatus::FEATURES_OK) {
+            debug!("Device did not accept negotiated feature bits {negotiated_features:x?}");
+            return Err(Error::Unsupported);
+        }
 
         self.set_guest_page_size(PAGE_SIZE as u32);
 
-        negotiated_features
+        Ok(negotiated_features)
     }
 
     /// Finishes initializing the device.


### PR DESCRIPTION
The virtio-msg transport allows devices to immediately respond with a the current status field after a driver tries to set it. During virtio feature negotiation a driver may attempt to set FEATURES_OK and if a device does not accept the subset of features the driver chose the device can clear FEATURES_OK in the response. This commit handles that case by changing the `Transport` trait's `set_transport` to return `Option<DeviceStatus>` for transports that do immediately respond like virtio-msg. `Transport::begin_init` then uses this response if available to check if it should continue setting up the device or return an error to the caller. It also updates its callers (device-specific code) to bubble up this error. This change ensures that if a device ignores the FEATURES_OK bit when a driver tries to set it the driver will not continue trying to set up the device.