### PR TITLE
Fix potential races and papercuts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,16 @@ enumn = "0.1.14"
 embedded-io = { version = "0.6.1", optional = true }
 thiserror = { version = "2.0.11", default-features = false }
 zerocopy = { version = "0.8.14", features = ["derive"] }
+spin = { version = "0.9.8", optional = true, default-features = false, features = [
+  "mutex",
+  "spin_mutex",
+] }
 
 [features]
 default = ["alloc", "embedded-io"]
 alloc = ["zerocopy/alloc"]
 embedded-io = ["dep:embedded-io"]
+spin = ["dep:spin"]
 
 [dev-dependencies]
 zerocopy = { version = "0.8.14", features = ["alloc"] }

--- a/examples/aarch64/Cargo.toml
+++ b/examples/aarch64/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.4.22"
 pl011-uart = "0.1.0"
 smccc = "0.1.1"
 spin = "0.9.8"
-virtio-drivers-and-devices = { path = "../.." }
+virtio-drivers-and-devices = { path = "../..", features = ["spin"] }
 
 [build-dependencies]
 cc = "1.0.73"

--- a/examples/aarch64/src/main.rs
+++ b/examples/aarch64/src/main.rs
@@ -45,6 +45,7 @@ use virtio_drivers_and_devices::{
         },
         DeviceType, Transport,
     },
+    SpinLockFactory,
 };
 
 /// Base memory-mapped address of the primary PL011 UART device.
@@ -231,8 +232,9 @@ fn virtio_console<T: Transport>(transport: T) {
 }
 
 fn virtio_socket<T: Transport>(transport: T) -> virtio_drivers_and_devices::Result<()> {
-    let mut socket = VsockConnectionManager::new(
-        VirtIOSocket::<HalImpl, T>::new(transport).expect("Failed to create socket driver"),
+    let socket = VsockConnectionManager::new(
+        VirtIOSocket::<HalImpl, T, SpinLockFactory>::new(transport)
+            .expect("Failed to create socket driver"),
     );
     let port = 1221;
     let host_address = VsockAddr {

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -622,7 +622,6 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
     // Polls the vsock device to receive data or other updates.
     pub fn poll_direct(&self) -> Result<Option<VsockEvent>> {
         let local_cid = self.driver.local_cid();
-        let per_connection_buffer_capacity = self.inner.lock().per_connection_buffer_capacity;
         self.driver.poll(|mut event, body| {
             if event.destination.cid != local_cid {
                 return Ok(None);
@@ -639,7 +638,7 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
                 let mut c = Connection::new(
                     event.source,
                     event.destination.port,
-                    per_connection_buffer_capacity,
+                    inner_guard.per_connection_buffer_capacity,
                 );
                 c.info.update_for_event(&event);
                 event.new_connection = Some(c);

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -1,5 +1,5 @@
 use super::{
-    protocol::VsockAddr, vsock::ConnectionInfo, SocketError, VirtIOSocket,
+    protocol::VsockAddr, vsock::ConnectionInfo, DisconnectReason, SocketError, VirtIOSocket,
     VirtIOSocketDevice, VirtIOSocketManager, VsockEvent, VsockEventType, DEFAULT_RX_BUFFER_SIZE,
 };
 use crate::{
@@ -64,6 +64,7 @@ pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: Loc
 /// the device side must not call the connect method. These are equivalent to the inherent methods
 /// which are kept for backwards compatibility.
 pub trait VsockManager: Send + Sync {
+    /// Accepts an incoming connection, registering it and acknowledging it to the peer.
     fn accept(&self, c: Connection) -> Result;
     /// Sends a request to connect to the given destination on the driver side.
     ///
@@ -86,6 +87,13 @@ pub trait VsockManager: Send + Sync {
 
     /// Polls the vsock device to receive data or other updates.
     fn poll(&self) -> Result<Option<VsockEvent>>;
+
+    /// Polls the vsock device, surfacing events directly to the caller without automatically
+    /// accepting or rejecting connections.
+    ///
+    /// Unlike [`poll`](Self::poll), an incoming `ConnectionRequest` is returned with its
+    /// `new_connection` populated so the caller can decide whether to [`accept`](Self::accept) it.
+    fn poll_direct(&self) -> Result<Option<VsockEvent>>;
 
     /// Returns the local CID, i.e. the CID of the guest on the driver side and the CID of the host
     /// on the device side.
@@ -178,6 +186,7 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
         self.0.local_cid()
     }
 
+    /// Accepts an incoming connection, registering it and acknowledging it to the peer.
     pub fn accept(&self, c: Connection) -> Result {
         let info = c.info.clone();
         // Adding the connection to the list before we call `accept` prevents a
@@ -231,6 +240,12 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// Polls the vsock device to receive data or other updates.
     pub fn poll(&self) -> Result<Option<VsockEvent>> {
         self.0.poll()
+    }
+
+    /// Polls the vsock device, surfacing events directly to the caller without automatically
+    /// accepting or rejecting connections. See [`VsockManager::poll_direct`].
+    pub fn poll_direct(&self) -> Result<Option<VsockEvent>> {
+        self.0.poll_direct()
     }
 
     /// Reads data received from the given connection.
@@ -304,6 +319,7 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
         self.0.unlisten(port)
     }
 
+    /// Accepts an incoming connection, registering it and acknowledging it to the peer.
     pub fn accept(&self, c: Connection) -> Result {
         let info = c.info.clone();
         // Adding the connection to the list before we call `accept` prevents a
@@ -325,6 +341,12 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
     /// Polls the vsock device to receive data or other updates.
     pub fn poll(&self) -> Result<Option<VsockEvent>> {
         self.0.poll()
+    }
+
+    /// Polls the vsock device, surfacing events directly to the caller without automatically
+    /// accepting or rejecting connections. See [`VsockManager::poll_direct`].
+    pub fn poll_direct(&self) -> Result<Option<VsockEvent>> {
+        self.0.poll_direct()
     }
 
     /// Reads data received from the given connection.
@@ -390,6 +412,9 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
     fn poll(&self) -> Result<Option<VsockEvent>> {
         Self::poll(self)
     }
+    fn poll_direct(&self) -> Result<Option<VsockEvent>> {
+        Self::poll_direct(self)
+    }
     fn local_cid(&self) -> u64 {
         self.0.local_cid()
     }
@@ -430,6 +455,9 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     }
     fn poll(&self) -> Result<Option<VsockEvent>> {
         Self::poll(self)
+    }
+    fn poll_direct(&self) -> Result<Option<VsockEvent>> {
+        Self::poll_direct(self)
     }
     fn local_cid(&self) -> u64 {
         self.0.local_cid()
@@ -475,7 +503,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
         let per_connection_buffer_capacity = inner.per_connection_buffer_capacity;
 
         let result = self.driver.poll(|event, body| {
-            let connection = get_connection_for_event::<F>(&inner.connections, &event, local_cid);
+            let connection = get_connection_for_event::<L>(&inner.connections, &event, local_cid);
 
             // Skip events which don't match any connection we know about, unless they are a
             // connection request.
@@ -489,7 +517,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
                 drop(connection);
                 // Add the new connection to our list, at least for now. It will be removed again
                 // below if we weren't listening on the port.
-                inner.connections.push(F::Lock::new(Connection::new(
+                inner.connections.push(L::Lock::new(Connection::new(
                     event.source,
                     event.destination.port,
                     per_connection_buffer_capacity,
@@ -517,7 +545,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
         };
         // The connection must exist because we found it above in the callback.
         let (connection_index, mut connection) =
-            get_connection_for_event::<F>(&inner.connections, &event, local_cid).unwrap();
+            get_connection_for_event::<L>(&inner.connections, &event, local_cid).unwrap();
 
         match event.event_type {
             VsockEventType::ConnectionRequest => {

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -121,14 +121,14 @@ struct VsockConnectionManagerInner<L: LockFactory> {
     listening_ports: Vec<u32>,
 }
 
-struct VsockConnectionManagerCommon<M: VirtIOSocketManager, L: LockFactory> {
+struct VsockConnectionManagerCommon<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory> {
     driver: M,
     inner: L::Lock<VsockConnectionManagerInner<L>>,
 }
 
 #[derive(Debug)]
-struct Connection {
-    info: ConnectionInfo,
+pub(crate) struct Connection {
+    pub(crate) info: ConnectionInfo,
     buffer: RingBuffer,
     /// The peer sent a SHUTDOWN request, but we haven't yet responded with a RST because there is
     /// still data in the buffer.
@@ -192,10 +192,11 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
 
         let new_connection =
             Connection::new(destination, src_port, inner.per_connection_buffer_capacity);
+        let new_connection = L::Lock::new(new_connection);
 
-        self.0.driver.connect(&new_connection.info)?;
-        debug!("Connection requested: {:?}", new_connection.info);
-        inner.connections.push(L::Lock::new(new_connection));
+        self.0.driver.connect(new_connection.lock())?;
+        debug!("Connection requested: {:?}", new_connection.lock().info);
+        inner.connections.push(new_connection);
         Ok(())
     }
     /// Allows incoming connections on the given port number.
@@ -411,7 +412,9 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     }
 }
 
-impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> {
+impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
+    VsockConnectionManagerCommon<M, L>
+{
     /// Allows incoming connections on the given port number.
     pub fn listen(&self, port: u32) {
         let mut inner = self.inner.lock();
@@ -428,9 +431,9 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
     /// Sends the buffer to the destination.
     pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         let inner = self.inner.lock();
-        let (_, mut connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
+        let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.send(buffer, &mut connection.info)
+        self.driver.send(buffer, connection)
     }
 
     /// Polls the vsock device to receive data or other updates.
@@ -488,11 +491,10 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         match event.event_type {
             VsockEventType::ConnectionRequest => {
                 if inner.listening_ports.contains(&event.destination.port) {
-                    self.driver.accept(&connection.info)?;
+                    self.driver.accept(connection)?;
                 } else {
                     // Reject the connection request and remove it from our list.
-                    self.driver.force_close(&connection.info)?;
-                    drop(connection);
+                    self.driver.force_close(connection)?;
                     inner.connections.swap_remove(connection_index);
 
                     // No need to pass the request on to the client, as we've already rejected it.
@@ -504,9 +506,13 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
                 // Wait until client reads all data before removing connection.
                 if connection.buffer.is_empty() {
                     if reason == DisconnectReason::Shutdown {
-                        self.driver.force_close(&connection.info)?;
+                        self.driver.force_close(connection)?;
+                    } else {
+                        // We need to drop `connection` before mutating the array.
+                        // `force_close` takes ownership of it on the other branch,
+                        // so we drop it explicitly here.
+                        drop(connection);
                     }
-                    drop(connection);
                     inner.connections.swap_remove(connection_index);
                 } else {
                     connection.peer_requested_shutdown = true;
@@ -517,7 +523,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
             }
             VsockEventType::CreditRequest => {
                 // If the peer requested credit, send an update.
-                self.driver.credit_update(&connection.info)?;
+                self.driver.credit_update(connection)?;
                 // No need to pass the request on to the client, we've already handled it.
                 return Ok(None);
             }
@@ -546,8 +552,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.
         if connection.peer_requested_shutdown && connection.buffer.is_empty() {
-            self.driver.force_close(&connection.info)?;
-            drop(connection);
+            self.driver.force_close(connection)?;
             inner.connections.swap_remove(connection_index);
         }
 
@@ -568,7 +573,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
     pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
-        self.driver.credit_update(&connection.info)
+        self.driver.credit_update(connection)
     }
 
     /// Blocks until we get some event from the vsock device.
@@ -592,7 +597,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.shutdown(&connection.info)
+        self.driver.shutdown(connection)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
@@ -600,8 +605,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         let mut inner = self.inner.lock();
         let (index, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.force_close(&connection.info)?;
-        drop(connection);
+        self.driver.force_close(connection)?;
 
         inner.connections.swap_remove(index);
         Ok(())

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     transport::{DeviceTransport, InterruptStatus, Transport},
-    DeviceHal, Hal, Result,
+    DeviceHal, Hal, Lock, LockFactory, Result,
 };
 use alloc::{boxed::Box, vec::Vec};
 use core::cmp::min;
@@ -49,12 +49,13 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 pub struct VsockConnectionManager<
     H: Hal,
     T: Transport,
+    L: LockFactory,
     const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
->(VsockConnectionManagerCommon<VirtIOSocket<H, T, RX_BUFFER_SIZE>>);
+>(VsockConnectionManagerCommon<VirtIOSocket<H, T, RX_BUFFER_SIZE>, L>);
 
 /// A high level interface for VirtIO socket (vsock) devices.
-pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport>(
-    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T>>,
+pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: LockFactory>(
+    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T>, L>,
 );
 
 /// A trait defining shared behavior for VirtIO socket devices and drivers.
@@ -62,28 +63,28 @@ pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport>(
 /// All methods are implemented for VsockConnectionManager and VsockDeviceConnectionManager though
 /// the device side must not call the connect method. These are equivalent to the inherent methods
 /// which are kept for backwards compatibility.
-pub trait VsockManager {
+pub trait VsockManager: Send + Sync {
     /// Sends a request to connect to the given destination on the driver side.
     ///
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data. This panics if called from the device side.
-    fn connect(&mut self, destination: VsockAddr, src_port: u32) -> Result;
+    fn connect(&self, destination: VsockAddr, src_port: u32) -> Result;
 
     /// Sends the buffer to the destination.
-    fn send(&mut self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result;
+    fn send(&self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result;
 
     /// Sends a credit update to the given peer.
-    fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result;
+    fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result;
 
     /// Forcibly closes the connection without waiting for the peer.
-    fn force_close(&mut self, dest: VsockAddr, src_port: u32) -> Result;
+    fn force_close(&self, dest: VsockAddr, src_port: u32) -> Result;
 
     /// Allows incoming connections on the given port number.
-    fn listen(&mut self, port: u32);
+    fn listen(&self, port: u32);
 
     /// Polls the vsock device to receive data or other updates.
-    fn poll(&mut self) -> Result<Option<VsockEvent>>;
+    fn poll(&self) -> Result<Option<VsockEvent>>;
 
     /// Returns the local CID, i.e. the CID of the guest on the driver side and the CID of the host
     /// on the device side.
@@ -95,28 +96,35 @@ pub trait VsockManager {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown(&mut self, dest: VsockAddr, src_port: u32) -> Result;
+    fn shutdown(&self, dest: VsockAddr, src_port: u32) -> Result;
 
     /// Reads data received from the given connection.
-    fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize>;
+    fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize>;
 
-    /// Acknowledges an interrupt using a pointer to the VsockManager impl
+    /// Acknowledges an interrupt from the device.
     ///
-    /// This is useful when you cannot soundly get a mutable reference to the VsockManager impl. It
-    /// may only be called on the driver side as it will panic if called on the device side.
+    /// This is useful when you cannot soundly get a mutable reference to the VsockManager impl, such
+    /// as from an interrupt handler. It may only be called on the driver side as it will panic if
+    /// called on the device side.
     ///
     /// # Safety
     ///
-    /// `ptr` must point to an initialized VsockManager impl which is ready to acknowledge
-    /// interrupts.
-    unsafe fn ack_interrupt(ptr: *mut Self) -> InterruptStatus;
+    /// The implementation may acknowledge the interrupt through a raw pointer derived from `&self`,
+    /// mutating the underlying transport. The caller must ensure that no other references to the
+    /// driver or its transport are concurrently active for the duration of this call.
+    unsafe fn ack_interrupt(&self) -> InterruptStatus;
 }
 
-struct VsockConnectionManagerCommon<M: VirtIOSocketManager> {
-    driver: M,
+struct VsockConnectionManagerInner<L: LockFactory> {
     per_connection_buffer_capacity: u32,
-    connections: Vec<Connection>,
+    connections: Vec<L::Lock<Connection>>,
     listening_ports: Vec<u32>,
+}
+
+struct VsockConnectionManagerCommon<M: VirtIOSocketManager, L: LockFactory> {
+    // TODO: remove the Lock here once VirtIOSocketManager is also thread-safe
+    driver: L::Lock<M>,
+    inner: L::Lock<VsockConnectionManagerInner<L>>,
 }
 
 #[derive(Debug)]
@@ -140,8 +148,8 @@ impl Connection {
     }
 }
 
-impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
-    VsockConnectionManager<H, T, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
+    VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
 {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
     pub fn new(driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>) -> Self {
@@ -155,10 +163,12 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
-            driver,
-            connections: Vec::new(),
-            listening_ports: Vec::new(),
-            per_connection_buffer_capacity,
+            driver: L::Lock::new(driver),
+            inner: L::Lock::new(VsockConnectionManagerInner {
+                connections: Vec::new(),
+                listening_ports: Vec::new(),
+                per_connection_buffer_capacity,
+            }),
         })
     }
 
@@ -172,43 +182,46 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
-    pub fn connect(&mut self, destination: VsockAddr, src_port: u32) -> Result {
-        if self.0.connections.iter().any(|connection| {
+    pub fn connect(&self, destination: VsockAddr, src_port: u32) -> Result {
+        let mut driver = self.0.driver.lock();
+        let mut inner = self.0.inner.lock();
+        if inner.connections.iter().any(|connection| {
+            let connection = connection.lock();
             connection.info.dst == destination && connection.info.src_port == src_port
         }) {
             return Err(SocketError::ConnectionExists.into());
         }
 
         let new_connection =
-            Connection::new(destination, src_port, self.0.per_connection_buffer_capacity);
+            Connection::new(destination, src_port, inner.per_connection_buffer_capacity);
 
-        self.0.driver.connect(&new_connection.info)?;
+        driver.connect(&new_connection.info)?;
         debug!("Connection requested: {:?}", new_connection.info);
-        self.0.connections.push(new_connection);
+        inner.connections.push(L::Lock::new(new_connection));
         Ok(())
     }
     /// Allows incoming connections on the given port number.
-    pub fn listen(&mut self, port: u32) {
+    pub fn listen(&self, port: u32) {
         self.0.listen(port)
     }
 
     /// Stops allowing incoming connections on the given port number.
-    pub fn unlisten(&mut self, port: u32) {
+    pub fn unlisten(&self, port: u32) {
         self.0.unlisten(port)
     }
 
     /// Sends the buffer to the destination.
-    pub fn send(&mut self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+    pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         self.0.send(destination, src_port, buffer)
     }
 
     /// Polls the vsock device to receive data or other updates.
-    pub fn poll(&mut self) -> Result<Option<VsockEvent>> {
+    pub fn poll(&self) -> Result<Option<VsockEvent>> {
         self.0.poll()
     }
 
     /// Reads data received from the given connection.
-    pub fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+    pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         self.0.recv(peer, src_port, buffer)
     }
 
@@ -216,17 +229,17 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     ///
     /// When the available bytes is 0, it indicates that the receive buffer is empty and does not
     /// contain any data.
-    pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+    pub fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         self.0.recv_buffer_available_bytes(peer, src_port)
     }
 
     /// Sends a credit update to the given peer.
-    pub fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
+    pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         self.0.update_credit(peer, src_port)
     }
 
     /// Blocks until we get some event from the vsock device.
-    pub fn wait_for_event(&mut self) -> Result<VsockEvent> {
+    pub fn wait_for_event(&self) -> Result<VsockEvent> {
         self.0.wait_for_event()
     }
 
@@ -236,17 +249,17 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize>
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+    pub fn shutdown(&self, destination: VsockAddr, src_port: u32) -> Result {
         self.0.shutdown(destination, src_port)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub fn force_close(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+    pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
         self.0.force_close(destination, src_port)
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport> VsockDeviceConnectionManager<H, T> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionManager<H, T, L> {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
     pub fn new(driver: VirtIOSocketDevice<H, T>) -> Self {
         Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
@@ -259,35 +272,37 @@ impl<H: DeviceHal, T: DeviceTransport> VsockDeviceConnectionManager<H, T> {
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
-            driver,
-            connections: Vec::new(),
-            listening_ports: Vec::new(),
-            per_connection_buffer_capacity,
+            driver: L::Lock::new(driver),
+            inner: L::Lock::new(VsockConnectionManagerInner {
+                connections: Vec::new(),
+                listening_ports: Vec::new(),
+                per_connection_buffer_capacity,
+            }),
         })
     }
 
     /// Allows incoming connections on the given port number.
-    pub fn listen(&mut self, port: u32) {
+    pub fn listen(&self, port: u32) {
         self.0.listen(port)
     }
 
     /// Stops allowing incoming connections on the given port number.
-    pub fn unlisten(&mut self, port: u32) {
+    pub fn unlisten(&self, port: u32) {
         self.0.unlisten(port)
     }
 
     /// Sends the buffer to the destination.
-    pub fn send(&mut self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+    pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         self.0.send(destination, src_port, buffer)
     }
 
     /// Polls the vsock device to receive data or other updates.
-    pub fn poll(&mut self) -> Result<Option<VsockEvent>> {
+    pub fn poll(&self) -> Result<Option<VsockEvent>> {
         self.0.poll()
     }
 
     /// Reads data received from the given connection.
-    pub fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+    pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         self.0.recv(peer, src_port, buffer)
     }
 
@@ -295,17 +310,17 @@ impl<H: DeviceHal, T: DeviceTransport> VsockDeviceConnectionManager<H, T> {
     ///
     /// When the available bytes is 0, it indicates that the receive buffer is empty and does not
     /// contain any data.
-    pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+    pub fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         self.0.recv_buffer_available_bytes(peer, src_port)
     }
 
     /// Sends a credit update to the given peer.
-    pub fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
+    pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         self.0.update_credit(peer, src_port)
     }
 
     /// Blocks until we get some event from the vsock device.
-    pub fn wait_for_event(&mut self) -> Result<VsockEvent> {
+    pub fn wait_for_event(&self) -> Result<VsockEvent> {
         self.0.wait_for_event()
     }
 
@@ -315,134 +330,140 @@ impl<H: DeviceHal, T: DeviceTransport> VsockDeviceConnectionManager<H, T> {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+    pub fn shutdown(&self, destination: VsockAddr, src_port: u32) -> Result {
         self.0.shutdown(destination, src_port)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub fn force_close(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+    pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
         self.0.force_close(destination, src_port)
     }
 }
 
-impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VsockManager
-    for VsockConnectionManager<H, T, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockManager
+    for VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
 {
-    fn connect(&mut self, destination: VsockAddr, src_port: u32) -> Result {
+    fn connect(&self, destination: VsockAddr, src_port: u32) -> Result {
         Self::connect(self, destination, src_port)
     }
-    fn send(&mut self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+    fn send(&self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         Self::send(self, dest, src_port, buffer)
     }
-    fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
+    fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         Self::update_credit(self, peer, src_port)
     }
-    fn force_close(&mut self, dest: VsockAddr, src_port: u32) -> Result {
+    fn force_close(&self, dest: VsockAddr, src_port: u32) -> Result {
         Self::force_close(self, dest, src_port)
     }
-    fn listen(&mut self, port: u32) {
+    fn listen(&self, port: u32) {
         Self::listen(self, port)
     }
-    fn poll(&mut self) -> Result<Option<VsockEvent>> {
+    fn poll(&self) -> Result<Option<VsockEvent>> {
         Self::poll(self)
     }
     fn local_cid(&self) -> u64 {
         self.0.local_cid()
     }
-    fn shutdown(&mut self, dest: VsockAddr, src_port: u32) -> Result {
+    fn shutdown(&self, dest: VsockAddr, src_port: u32) -> Result {
         Self::shutdown(self, dest, src_port)
     }
-    fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+    fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         Self::recv(self, peer, src_port, buffer)
     }
-    unsafe fn ack_interrupt(ptr: *mut Self) -> InterruptStatus {
-        // SAFETY: This function's safety requirements ensure that `ptr` points to a valid
+    unsafe fn ack_interrupt(&self) -> InterruptStatus {
+        let vsock_driver_ptr = self.0.driver.data_ptr();
+        // SAFETY: This function's safety requirements ensure that `self` points to a valid
         // VsockConnectionManager so this gives a valid pointer to the field.
-        let vsock_driver_ptr = unsafe { &raw mut (*ptr).0.driver };
-        // SAFETY: delegated to the caller
         unsafe { VirtIOSocket::<H, T, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport> VsockManager for VsockDeviceConnectionManager<H, T> {
-    fn connect(&mut self, _destination: VsockAddr, _src_port: u32) -> Result {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
+    for VsockDeviceConnectionManager<H, T, L>
+{
+    fn connect(&self, _destination: VsockAddr, _src_port: u32) -> Result {
         unreachable!("vsock devices should not make outgoing connections")
     }
-    fn send(&mut self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+    fn send(&self, dest: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         Self::send(self, dest, src_port, buffer)
     }
-    fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
+    fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         Self::update_credit(self, peer, src_port)
     }
-    fn force_close(&mut self, dest: VsockAddr, src_port: u32) -> Result {
+    fn force_close(&self, dest: VsockAddr, src_port: u32) -> Result {
         Self::force_close(self, dest, src_port)
     }
-    fn listen(&mut self, port: u32) {
+    fn listen(&self, port: u32) {
         Self::listen(self, port)
     }
-    fn poll(&mut self) -> Result<Option<VsockEvent>> {
+    fn poll(&self) -> Result<Option<VsockEvent>> {
         Self::poll(self)
     }
     fn local_cid(&self) -> u64 {
         self.0.local_cid()
     }
-    fn shutdown(&mut self, dest: VsockAddr, src_port: u32) -> Result {
+    fn shutdown(&self, dest: VsockAddr, src_port: u32) -> Result {
         Self::shutdown(self, dest, src_port)
     }
-    fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+    fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         Self::recv(self, peer, src_port, buffer)
     }
-    unsafe fn ack_interrupt(_ptr: *mut Self) -> InterruptStatus {
+    unsafe fn ack_interrupt(&self) -> InterruptStatus {
         panic!("vsock devices cannot acknowledge interrupts")
     }
 }
 
-impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
+impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> {
     /// Allows incoming connections on the given port number.
-    pub fn listen(&mut self, port: u32) {
-        if !self.listening_ports.contains(&port) {
-            self.listening_ports.push(port);
+    pub fn listen(&self, port: u32) {
+        let mut inner = self.inner.lock();
+        if !inner.listening_ports.contains(&port) {
+            inner.listening_ports.push(port);
         }
     }
 
     /// Stops allowing incoming connections on the given port number.
-    pub fn unlisten(&mut self, port: u32) {
-        self.listening_ports.retain(|p| *p != port);
+    pub fn unlisten(&self, port: u32) {
+        self.inner.lock().listening_ports.retain(|p| *p != port);
     }
 
     /// Sends the buffer to the destination.
-    pub fn send(&mut self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
-        let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+    pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
+        let mut driver = self.driver.lock();
+        let inner = self.inner.lock();
+        let (_, mut connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.send(buffer, &mut connection.info)
+        driver.send(buffer, &mut connection.info)
     }
 
     /// Polls the vsock device to receive data or other updates.
-    pub fn poll(&mut self) -> Result<Option<VsockEvent>> {
-        let local_cid = self.driver.local_cid();
-        let connections = &mut self.connections;
-        let per_connection_buffer_capacity = self.per_connection_buffer_capacity;
+    pub fn poll(&self) -> Result<Option<VsockEvent>> {
+        let mut driver = self.driver.lock();
+        let mut inner = self.inner.lock();
+        let local_cid = driver.local_cid();
+        let per_connection_buffer_capacity = inner.per_connection_buffer_capacity;
 
-        let result = self.driver.poll(|event, body| {
-            let connection = get_connection_for_event(connections, &event, local_cid);
+        let result = driver.poll(|event, body| {
+            let connection = get_connection_for_event::<L>(&inner.connections, &event, local_cid);
 
             // Skip events which don't match any connection we know about, unless they are a
             // connection request.
-            let connection = if let Some((_, connection)) = connection {
+            let mut connection = if let Some((_, connection)) = connection {
                 connection
             } else if let VsockEventType::ConnectionRequest = event.event_type {
                 // If the requested connection already exists or the CID isn't ours, ignore it.
                 if connection.is_some() || event.destination.cid != local_cid {
                     return Ok(None);
                 }
+                drop(connection);
                 // Add the new connection to our list, at least for now. It will be removed again
                 // below if we weren't listening on the port.
-                connections.push(Connection::new(
+                inner.connections.push(L::Lock::new(Connection::new(
                     event.source,
                     event.destination.port,
                     per_connection_buffer_capacity,
-                ));
-                connections.last_mut().unwrap()
+                )));
+                inner.connections.last_mut().unwrap().lock()
             } else {
                 return Ok(None);
             };
@@ -465,17 +486,18 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
         };
 
         // The connection must exist because we found it above in the callback.
-        let (connection_index, connection) =
-            get_connection_for_event(connections, &event, local_cid).unwrap();
+        let (connection_index, mut connection) =
+            get_connection_for_event::<L>(&inner.connections, &event, local_cid).unwrap();
 
         match event.event_type {
             VsockEventType::ConnectionRequest => {
-                if self.listening_ports.contains(&event.destination.port) {
-                    self.driver.accept(&connection.info)?;
+                if inner.listening_ports.contains(&event.destination.port) {
+                    driver.accept(&connection.info)?;
                 } else {
                     // Reject the connection request and remove it from our list.
-                    self.driver.force_close(&connection.info)?;
-                    self.connections.swap_remove(connection_index);
+                    driver.force_close(&connection.info)?;
+                    drop(connection);
+                    inner.connections.swap_remove(connection_index);
 
                     // No need to pass the request on to the client, as we've already rejected it.
                     return Ok(None);
@@ -486,9 +508,10 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
                 // Wait until client reads all data before removing connection.
                 if connection.buffer.is_empty() {
                     if reason == DisconnectReason::Shutdown {
-                        self.driver.force_close(&connection.info)?;
+                        driver.force_close(&connection.info)?;
                     }
-                    self.connections.swap_remove(connection_index);
+                    drop(connection);
+                    inner.connections.swap_remove(connection_index);
                 } else {
                     connection.peer_requested_shutdown = true;
                 }
@@ -498,7 +521,7 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
             }
             VsockEventType::CreditRequest => {
                 // If the peer requested credit, send an update.
-                self.driver.credit_update(&connection.info)?;
+                driver.credit_update(&connection.info)?;
                 // No need to pass the request on to the client, we've already handled it.
                 return Ok(None);
             }
@@ -510,12 +533,15 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
 
     /// Returns the local CID of the vsock device.
     pub fn local_cid(&self) -> u64 {
-        self.driver.local_cid()
+        self.driver.lock().local_cid()
     }
 
     /// Reads data received from the given connection.
-    pub fn recv(&mut self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
-        let (connection_index, connection) = get_connection(&mut self.connections, peer, src_port)?;
+    pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
+        let mut driver = self.driver.lock();
+        let mut inner = self.inner.lock();
+        let (connection_index, mut connection) =
+            get_connection::<L>(&inner.connections, peer, src_port)?;
 
         // Copy from ring buffer
         let bytes_read = connection.buffer.drain(buffer);
@@ -525,8 +551,9 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.
         if connection.peer_requested_shutdown && connection.buffer.is_empty() {
-            self.driver.force_close(&connection.info)?;
-            self.connections.swap_remove(connection_index);
+            driver.force_close(&connection.info)?;
+            drop(connection);
+            inner.connections.swap_remove(connection_index);
         }
 
         Ok(bytes_read)
@@ -536,19 +563,22 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
     ///
     /// When the available bytes is 0, it indicates that the receive buffer is empty and does not
     /// contain any data.
-    pub fn recv_buffer_available_bytes(&mut self, peer: VsockAddr, src_port: u32) -> Result<usize> {
-        let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
+    pub fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+        let inner = self.inner.lock();
+        let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
         Ok(connection.buffer.used())
     }
 
     /// Sends a credit update to the given peer.
-    pub fn update_credit(&mut self, peer: VsockAddr, src_port: u32) -> Result {
-        let (_, connection) = get_connection(&mut self.connections, peer, src_port)?;
-        self.driver.credit_update(&connection.info)
+    pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
+        let mut driver = self.driver.lock();
+        let inner = self.inner.lock();
+        let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
+        driver.credit_update(&connection.info)
     }
 
     /// Blocks until we get some event from the vsock device.
-    pub fn wait_for_event(&mut self) -> Result<VsockEvent> {
+    pub fn wait_for_event(&self) -> Result<VsockEvent> {
         loop {
             if let Some(event) = self.poll()? {
                 return Ok(event);
@@ -564,19 +594,24 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown(&mut self, destination: VsockAddr, src_port: u32) -> Result {
-        let (_, connection) = get_connection(&mut self.connections, destination, src_port)?;
+    pub fn shutdown(&self, destination: VsockAddr, src_port: u32) -> Result {
+        let mut driver = self.driver.lock();
+        let inner = self.inner.lock();
+        let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.shutdown(&connection.info)
+        driver.shutdown(&connection.info)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub fn force_close(&mut self, destination: VsockAddr, src_port: u32) -> Result {
-        let (index, connection) = get_connection(&mut self.connections, destination, src_port)?;
+    pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
+        let mut driver = self.driver.lock();
+        let mut inner = self.inner.lock();
+        let (index, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        self.driver.force_close(&connection.info)?;
+        driver.force_close(&connection.info)?;
+        drop(connection);
 
-        self.connections.swap_remove(index);
+        inner.connections.swap_remove(index);
         Ok(())
     }
 }
@@ -585,30 +620,34 @@ impl<M: VirtIOSocketManager> VsockConnectionManagerCommon<M> {
 /// its index.
 ///
 /// Returns `Err(SocketError::NotConnected)` if there is no matching connection in the list.
-fn get_connection(
-    connections: &mut [Connection],
+fn get_connection<'a, L: LockFactory>(
+    connections: &'a [L::Lock<Connection>],
     peer: VsockAddr,
     local_port: u32,
-) -> core::result::Result<(usize, &mut Connection), SocketError> {
+) -> core::result::Result<(usize, <L::Lock<Connection> as Lock<Connection>>::Guard<'a>), SocketError>
+{
     connections
-        .iter_mut()
+        .iter()
         .enumerate()
         .find(|(_, connection)| {
+            let connection = connection.lock();
             connection.info.dst == peer && connection.info.src_port == local_port
         })
+        .map(|(idx, l)| (idx, l.lock()))
         .ok_or(SocketError::NotConnected)
 }
 
 /// Returns the connection from the given list matching the event, if any, and its index.
-fn get_connection_for_event<'a>(
-    connections: &'a mut [Connection],
+fn get_connection_for_event<'a, L: LockFactory>(
+    connections: &'a [L::Lock<Connection>],
     event: &VsockEvent,
     local_cid: u64,
-) -> Option<(usize, &'a mut Connection)> {
+) -> Option<(usize, <L::Lock<Connection> as Lock<Connection>>::Guard<'a>)> {
     connections
-        .iter_mut()
+        .iter()
         .enumerate()
-        .find(|(_, connection)| event.matches_connection(&connection.info, local_cid))
+        .find(|(_, connection)| event.matches_connection(&connection.lock().info, local_cid))
+        .map(|(idx, l)| (idx, l.lock()))
 }
 
 #[derive(Debug)]

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -110,6 +110,12 @@ pub trait VsockManager: Send + Sync {
     /// Reads data received from the given connection.
     fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize>;
 
+    /// Returns the number of bytes in the receive buffer available to be read by `recv`.
+    ///
+    /// When the available bytes is 0, it indicates that the receive buffer is empty and does not
+    /// contain any data.
+    fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize>;
+
     /// Acknowledges an interrupt from the device.
     ///
     /// This is useful when you cannot soundly get a mutable reference to the VsockManager impl, such
@@ -448,6 +454,9 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
     fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         Self::recv(self, peer, src_port, buffer)
     }
+    fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+        Self::recv_buffer_available_bytes(self, peer, src_port)
+    }
     unsafe fn ack_interrupt(&self) -> InterruptStatus {
         let vsock_driver_ptr = (&raw const self.0.driver).cast_mut();
         // SAFETY: This function's safety requirements ensure that `self` points to a valid
@@ -491,6 +500,9 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     }
     fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         Self::recv(self, peer, src_port, buffer)
+    }
+    fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
+        Self::recv_buffer_available_bytes(self, peer, src_port)
     }
     unsafe fn ack_interrupt(&self) -> InterruptStatus {
         panic!("vsock devices cannot acknowledge interrupts")

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -6,7 +6,7 @@ use crate::{
     transport::{DeviceTransport, InterruptStatus, Transport},
     DeviceHal, Hal, Lock, LockFactory, Result,
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::cmp::min;
 use core::convert::TryInto;
 use core::hint::spin_loop;
@@ -126,11 +126,11 @@ pub trait VsockManager: Send + Sync {
 
 struct VsockConnectionManagerInner<L: LockFactory> {
     per_connection_buffer_capacity: u32,
-    connections: Vec<L::Lock<Connection>>,
+    connections: Vec<Arc<L::Lock<Connection>>>,
     listening_ports: Vec<u32>,
 }
 
-struct VsockConnectionManagerCommon<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory> {
+struct VsockConnectionManagerCommon<M: VirtIOSocketManager<L>, L: LockFactory> {
     driver: M,
     inner: L::Lock<VsockConnectionManagerInner<L>>,
 }
@@ -189,15 +189,22 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// Accepts an incoming connection, registering it and acknowledging it to the peer.
     pub fn accept(&self, c: Connection) -> Result {
         let info = c.info.clone();
+        let new_connection = Arc::new(L::Lock::new(c));
         // Adding the connection to the list before we call `accept` prevents a
         // potential race where the peer could send follow-up packets before the
         // connection gets added to the list.
-        self.0.inner.lock().connections.push(L::Lock::new(c));
-        let res = self.0.driver.accept(info);
-        if res.is_err() {
-            panic!("need to remove connection")
+        self.0.inner.lock().connections.push(new_connection.clone());
+        if let Err(e) = self.0.driver.accept(info) {
+            // We unlocked inner so connections could have changed. Remove newly
+            // inserted connection via lookup rather than by possibly-stale idx.
+            self.0
+                .inner
+                .lock()
+                .connections
+                .retain(|c| !Arc::ptr_eq(c, &new_connection));
+            return Err(e);
         }
-        res
+        Ok(())
     }
     /// Sends a request to connect to the given destination.
     ///
@@ -215,11 +222,21 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
 
         let new_connection =
             Connection::new(destination, src_port, inner.per_connection_buffer_capacity);
-        let new_connection = L::Lock::new(new_connection);
+        let new_connection = Arc::new(L::Lock::new(new_connection));
+        inner.connections.push(new_connection.clone());
+        drop(inner);
 
-        self.0.driver.connect(new_connection.lock())?;
+        if let Err(e) = self.0.driver.connect(new_connection.clone()) {
+            // We unlocked inner so connections could have changed. Remove newly
+            // inserted connection via lookup rather than by possibly-stale idx.
+            self.0
+                .inner
+                .lock()
+                .connections
+                .retain(|c| !Arc::ptr_eq(c, &new_connection));
+            return Err(e);
+        }
         debug!("Connection requested: {:?}", new_connection.lock().info);
-        inner.connections.push(new_connection);
         Ok(())
     }
     /// Allows incoming connections on the given port number.
@@ -322,15 +339,22 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
     /// Accepts an incoming connection, registering it and acknowledging it to the peer.
     pub fn accept(&self, c: Connection) -> Result {
         let info = c.info.clone();
+        let new_connection = Arc::new(L::Lock::new(c));
         // Adding the connection to the list before we call `accept` prevents a
         // potential race where the peer could send follow-up packets before the
         // connection gets added to the list.
-        self.0.inner.lock().connections.push(L::Lock::new(c));
-        let res = self.0.driver.accept(info);
-        if res.is_err() {
-            panic!("need to remove connection")
+        self.0.inner.lock().connections.push(new_connection.clone());
+        if let Err(e) = <_ as VirtIOSocketManager<L>>::accept(&self.0.driver, info) {
+            // We unlocked inner so connections could have changed. Remove newly
+            // inserted connection via lookup rather than by possibly-stale idx.
+            self.0
+                .inner
+                .lock()
+                .connections
+                .retain(|c| !Arc::ptr_eq(c, &new_connection));
+            return Err(e);
         }
-        res
+        Ok(())
     }
 
     /// Sends the buffer to the destination.
@@ -473,9 +497,7 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     }
 }
 
-impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
-    VsockConnectionManagerCommon<M, L>
-{
+impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, L> {
     /// Allows incoming connections on the given port number.
     pub fn listen(&self, port: u32) {
         let mut inner = self.inner.lock();
@@ -493,6 +515,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
+        drop(inner);
 
         self.driver.send(buffer, connection)
     }
@@ -507,26 +530,27 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
 
             // Skip events which don't match any connection we know about, unless they are a
             // connection request.
-            let mut connection = if let Some((_, connection)) = connection {
+            let connection = if let Some((_, connection)) = connection {
                 connection
             } else if let VsockEventType::ConnectionRequest = event.event_type {
                 // If the requested connection already exists or the CID isn't ours, ignore it.
                 if connection.is_some() || event.destination.cid != local_cid {
                     return Ok(None);
                 }
-                drop(connection);
                 // Add the new connection to our list, at least for now. It will be removed again
                 // below if we weren't listening on the port.
-                inner.connections.push(L::Lock::new(Connection::new(
+                let new_connection = Arc::new(L::Lock::new(Connection::new(
                     event.source,
                     event.destination.port,
                     per_connection_buffer_capacity,
                 )));
-                inner.connections.last_mut().unwrap().lock()
+                inner.connections.push(new_connection.clone());
+                new_connection
             } else {
                 return Ok(None);
             };
 
+            let mut connection = connection.lock();
             // Update stored connection info.
             connection.info.update_for_event(&event);
 
@@ -544,17 +568,20 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
             return Ok(None);
         };
         // The connection must exist because we found it above in the callback.
-        let (connection_index, mut connection) =
+        let (connection_index, connection) =
             get_connection_for_event::<L>(&inner.connections, &event, local_cid).unwrap();
 
         match event.event_type {
             VsockEventType::ConnectionRequest => {
                 if inner.listening_ports.contains(&event.destination.port) {
-                    self.driver.accept(connection.info.clone())?;
+                    drop(inner);
+                    self.driver.accept(connection.lock().info.clone())?;
                 } else {
+                    inner.connections.swap_remove(connection_index);
+                    drop(inner);
+
                     // Reject the connection request and remove it from our list.
                     self.driver.force_close(connection)?;
-                    inner.connections.swap_remove(connection_index);
 
                     // No need to pass the request on to the client, as we've already rejected it.
                     return Ok(None);
@@ -563,24 +590,24 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
             VsockEventType::Connected => {}
             VsockEventType::Disconnected { reason } => {
                 // Wait until client reads all data before removing connection.
-                if connection.buffer.is_empty() {
+                let mut connection_guard = connection.lock();
+                if connection_guard.buffer.is_empty() {
+                    inner.connections.swap_remove(connection_index);
+                    drop(connection_guard);
+                    drop(inner);
+
                     if reason == DisconnectReason::Shutdown {
                         self.driver.force_close(connection)?;
-                    } else {
-                        // We need to drop `connection` before mutating the array.
-                        // `force_close` takes ownership of it on the other branch,
-                        // so we drop it explicitly here.
-                        drop(connection);
                     }
-                    inner.connections.swap_remove(connection_index);
                 } else {
-                    connection.peer_requested_shutdown = true;
+                    connection_guard.peer_requested_shutdown = true;
                 }
             }
             VsockEventType::Received { .. } => {
                 // Already copied the buffer in the callback above.
             }
             VsockEventType::CreditRequest => {
+                drop(inner);
                 // If the peer requested credit, send an update.
                 self.driver.credit_update(connection)?;
                 // No need to pass the request on to the client, we've already handled it.
@@ -622,12 +649,14 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
                 // unknown connection.
                 return Ok(Some(event));
             }
-            let existing_connection =
-                get_connection_for_event::<L>(&inner_guard.connections, &event, local_cid);
-            if existing_connection.is_none() {
+            let Some((_, existing_connection)) =
+                get_connection_for_event::<L>(&inner_guard.connections, &event, local_cid)
+            else {
                 return Ok(None);
-            }
-            let mut existing_connection = existing_connection.unwrap().1;
+            };
+            drop(inner_guard);
+
+            let mut existing_connection = existing_connection.lock();
             existing_connection.info.update_for_event(&event);
 
             if let VsockEventType::Received { length } = event.event_type {
@@ -649,19 +678,23 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     /// Reads data received from the given connection.
     pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
         let mut inner = self.inner.lock();
-        let (connection_index, mut connection) =
+        let (connection_index, connection) =
             get_connection::<L>(&inner.connections, peer, src_port)?;
 
+        let mut connection_guard = connection.lock();
         // Copy from ring buffer
-        let bytes_read = connection.buffer.drain(buffer);
+        let bytes_read = connection_guard.buffer.drain(buffer);
 
-        connection.info.done_forwarding(bytes_read);
+        connection_guard.info.done_forwarding(bytes_read);
 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.
-        if connection.peer_requested_shutdown && connection.buffer.is_empty() {
-            self.driver.force_close(connection)?;
+        if connection_guard.peer_requested_shutdown && connection_guard.buffer.is_empty() {
             inner.connections.swap_remove(connection_index);
+            drop(connection_guard);
+            drop(inner);
+
+            self.driver.force_close(connection)?;
         }
 
         Ok(bytes_read)
@@ -674,6 +707,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     pub fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
+        let connection = connection.lock();
         Ok(connection.buffer.used())
     }
 
@@ -681,6 +715,8 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
+        drop(inner);
+
         self.driver.credit_update(connection)
     }
 
@@ -704,6 +740,7 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     pub fn shutdown(&self, destination: VsockAddr, src_port: u32) -> Result {
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
+        drop(inner);
 
         self.driver.shutdown(connection)
     }
@@ -712,10 +749,11 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
     pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
         let mut inner = self.inner.lock();
         let (index, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
+        inner.connections.swap_remove(index);
+        drop(inner);
 
         self.driver.force_close(connection)?;
 
-        inner.connections.swap_remove(index);
         Ok(())
     }
 }
@@ -724,12 +762,11 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
 /// its index.
 ///
 /// Returns `Err(SocketError::NotConnected)` if there is no matching connection in the list.
-fn get_connection<'a, L: LockFactory>(
-    connections: &'a [L::Lock<Connection>],
+fn get_connection<L: LockFactory>(
+    connections: &[Arc<L::Lock<Connection>>],
     peer: VsockAddr,
     local_port: u32,
-) -> core::result::Result<(usize, <L::Lock<Connection> as Lock<Connection>>::Guard<'a>), SocketError>
-{
+) -> core::result::Result<(usize, Arc<L::Lock<Connection>>), SocketError> {
     connections
         .iter()
         .enumerate()
@@ -737,21 +774,21 @@ fn get_connection<'a, L: LockFactory>(
             let connection = connection.lock();
             connection.info.dst == peer && connection.info.src_port == local_port
         })
-        .map(|(idx, l)| (idx, l.lock()))
+        .map(|(idx, connection)| (idx, Arc::clone(connection)))
         .ok_or(SocketError::NotConnected)
 }
 
 /// Returns the connection from the given list matching the event, if any, and its index.
-fn get_connection_for_event<'a, L: LockFactory>(
-    connections: &'a [L::Lock<Connection>],
+fn get_connection_for_event<L: LockFactory>(
+    connections: &[Arc<L::Lock<Connection>>],
     event: &VsockEvent,
     local_cid: u64,
-) -> Option<(usize, <L::Lock<Connection> as Lock<Connection>>::Guard<'a>)> {
+) -> Option<(usize, Arc<L::Lock<Connection>>)> {
     connections
         .iter()
         .enumerate()
         .find(|(_, connection)| event.matches_connection(&connection.lock().info, local_cid))
-        .map(|(idx, l)| (idx, l.lock()))
+        .map(|(idx, connection)| (idx, Arc::clone(connection)))
 }
 
 #[derive(Debug)]

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -634,7 +634,9 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
     // Polls the vsock device to receive data or other updates.
     pub fn poll_direct(&self) -> Result<Option<VsockEvent>> {
         let local_cid = self.driver.local_cid();
-        self.driver.poll(|mut event, body| {
+        // Reset sent after poll returns, since the RX queue lock is held in the callback.
+        let mut reject_info: Option<ConnectionInfo> = None;
+        let result = self.driver.poll(|mut event, body| {
             if event.destination.cid != local_cid {
                 return Ok(None);
             }
@@ -644,7 +646,7 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
                     .listening_ports
                     .contains(&event.destination.port)
                 {
-                    // TODO: Return reject connection action here instead
+                    reject_info = Some(ConnectionInfo::new(event.source, event.destination.port));
                     return Ok(None);
                 }
 
@@ -687,7 +689,13 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
             }
 
             Ok(Some(event))
-        })
+        })?;
+
+        if let Some(info) = reject_info {
+            self.driver.reject(info)?;
+            return Ok(None);
+        }
+        Ok(result)
     }
 
     /// Returns the local CID of the vsock device.

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -711,9 +711,8 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
 
     /// Reads data received from the given connection.
     pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
-        let mut inner = self.inner.lock();
-        let (connection_index, connection) =
-            get_connection::<L>(&inner.connections, peer, src_port)?;
+        let inner = self.inner.lock();
+        let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
 
         let mut connection_guard = connection.lock();
         // Copy from ring buffer
@@ -724,11 +723,15 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.
         if connection_guard.peer_requested_shutdown && connection_guard.buffer.is_empty() {
-            inner.connections.swap_remove(connection_index);
             drop(connection_guard);
             drop(inner);
 
-            self.driver.force_close(connection)?;
+            self.driver.force_close(Arc::clone(&connection))?;
+
+            self.inner
+                .lock()
+                .connections
+                .retain(|c| !Arc::ptr_eq(c, &connection));
         }
 
         Ok(bytes_read)
@@ -781,12 +784,17 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
 
     /// Forcibly closes the connection without waiting for the peer.
     pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
-        let mut inner = self.inner.lock();
-        let (index, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
-        inner.connections.swap_remove(index);
-        drop(inner);
+        let connection = {
+            let inner = self.inner.lock();
+            get_connection::<L>(&inner.connections, destination, src_port)?.1
+        };
 
-        self.driver.force_close(connection)?;
+        self.driver.force_close(Arc::clone(&connection))?;
+
+        self.inner
+            .lock()
+            .connections
+            .retain(|c| !Arc::ptr_eq(c, &connection));
 
         Ok(())
     }

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -64,6 +64,7 @@ pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: Loc
 /// the device side must not call the connect method. These are equivalent to the inherent methods
 /// which are kept for backwards compatibility.
 pub trait VsockManager: Send + Sync {
+    fn accept(&self, c: Connection) -> Result;
     /// Sends a request to connect to the given destination on the driver side.
     ///
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
@@ -177,6 +178,18 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
         self.0.local_cid()
     }
 
+    pub fn accept(&self, c: Connection) -> Result {
+        let info = c.info.clone();
+        // Adding the connection to the list before we call `accept` prevents a
+        // potential race where the peer could send follow-up packets before the
+        // connection gets added to the list.
+        self.0.inner.lock().connections.push(L::Lock::new(c));
+        let res = self.0.driver.accept(info);
+        if res.is_err() {
+            panic!("need to remove connection")
+        }
+        res
+    }
     /// Sends a request to connect to the given destination.
     ///
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
@@ -291,6 +304,19 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
         self.0.unlisten(port)
     }
 
+    pub fn accept(&self, c: Connection) -> Result {
+        let info = c.info.clone();
+        // Adding the connection to the list before we call `accept` prevents a
+        // potential race where the peer could send follow-up packets before the
+        // connection gets added to the list.
+        self.0.inner.lock().connections.push(L::Lock::new(c));
+        let res = self.0.driver.accept(info);
+        if res.is_err() {
+            panic!("need to remove connection")
+        }
+        res
+    }
+
     /// Sends the buffer to the destination.
     pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
         self.0.send(destination, src_port, buffer)
@@ -343,6 +369,9 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
 impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockManager
     for VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
 {
+    fn accept(&self, c: Connection) -> Result {
+        Self::accept(self, c)
+    }
     fn connect(&self, destination: VsockAddr, src_port: u32) -> Result {
         Self::connect(self, destination, src_port)
     }
@@ -381,6 +410,9 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
 impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     for VsockDeviceConnectionManager<H, T, L>
 {
+    fn accept(&self, c: Connection) -> Result {
+        Self::accept(self, c)
+    }
     fn connect(&self, _destination: VsockAddr, _src_port: u32) -> Result {
         unreachable!("vsock devices should not make outgoing connections")
     }

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -25,12 +25,12 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 /// # Example
 ///
 /// ```
-/// # use virtio_drivers_and_devices::{Error, Hal};
+/// # use virtio_drivers_and_devices::{Error, Hal, LockFactory};
 /// # use virtio_drivers_and_devices::transport::Transport;
 /// use virtio_drivers_and_devices::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
 ///
-/// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
-/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _, _>::new(transport)?);
+/// # fn example<HalImpl: Hal, T: Transport, L: LockFactory>(transport: T) -> Result<(), Error> {
+/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _, L>::new(transport)?);
 ///
 /// // Start a thread to call `socket.poll()` and handle events.
 ///
@@ -891,7 +891,7 @@ impl RingBuffer {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "spin"))]
 mod tests {
     use super::*;
     use crate::{
@@ -907,6 +907,7 @@ mod tests {
             fake::{FakeTransport, QueueStatus, State},
             DeviceType,
         },
+        SpinLockFactory,
     };
     use alloc::{sync::Arc, vec};
     use core::mem::size_of;
@@ -945,7 +946,10 @@ mod tests {
             state: state.clone(),
         };
         let mut socket = VsockConnectionManager::new(
-            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap(),
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>, SpinLockFactory>::new(
+                transport,
+            )
+            .unwrap(),
         );
 
         // Start a thread to simulate the device.
@@ -1076,19 +1080,21 @@ mod tests {
         });
 
         socket.connect(host_address, guest_port).unwrap();
+        let event = socket.wait_for_event().unwrap();
+        assert_eq!(event.source, host_address);
         assert_eq!(
-            socket.wait_for_event().unwrap(),
-            VsockEvent {
-                source: host_address,
-                destination: VsockAddr {
-                    cid: guest_cid,
-                    port: guest_port,
-                },
-                event_type: VsockEventType::Connected,
-                buffer_status: VsockBufferStatus {
-                    buffer_allocation: 50,
-                    forward_count: 0,
-                },
+            event.destination,
+            VsockAddr {
+                cid: guest_cid,
+                port: guest_port,
+            }
+        );
+        assert_eq!(event.event_type, VsockEventType::Connected);
+        assert_eq!(
+            event.buffer_status,
+            VsockBufferStatus {
+                buffer_allocation: 50,
+                forward_count: 0,
             }
         );
         println!("Guest sending");
@@ -1096,21 +1102,26 @@ mod tests {
             .send(host_address, guest_port, "Hello from guest".as_bytes())
             .unwrap();
         println!("Guest waiting to receive.");
+        let event = socket.wait_for_event().unwrap();
+        assert_eq!(event.source, host_address);
         assert_eq!(
-            socket.wait_for_event().unwrap(),
-            VsockEvent {
-                source: host_address,
-                destination: VsockAddr {
-                    cid: guest_cid,
-                    port: guest_port,
-                },
-                event_type: VsockEventType::Received {
-                    length: hello_from_host.len()
-                },
-                buffer_status: VsockBufferStatus {
-                    buffer_allocation: 50,
-                    forward_count: hello_from_guest.len() as u32,
-                },
+            event.destination,
+            VsockAddr {
+                cid: guest_cid,
+                port: guest_port,
+            }
+        );
+        assert_eq!(
+            event.event_type,
+            VsockEventType::Received {
+                length: hello_from_host.len()
+            }
+        );
+        assert_eq!(
+            event.buffer_status,
+            VsockBufferStatus {
+                buffer_allocation: 50,
+                forward_count: hello_from_guest.len() as u32,
             }
         );
         println!("Guest getting received data.");
@@ -1159,7 +1170,10 @@ mod tests {
             state: state.clone(),
         };
         let mut socket = VsockConnectionManager::new(
-            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap(),
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>, SpinLockFactory>::new(
+                transport,
+            )
+            .unwrap(),
         );
 
         socket.listen(guest_port);
@@ -1261,19 +1275,21 @@ mod tests {
 
         // Expect an incoming connection.
         println!("Guest expecting incoming connection.");
+        let event = socket.wait_for_event().unwrap();
+        assert_eq!(event.source, host_address);
         assert_eq!(
-            socket.wait_for_event().unwrap(),
-            VsockEvent {
-                source: host_address,
-                destination: VsockAddr {
-                    cid: guest_cid,
-                    port: guest_port,
-                },
-                event_type: VsockEventType::ConnectionRequest,
-                buffer_status: VsockBufferStatus {
-                    buffer_allocation: 50,
-                    forward_count: 0,
-                },
+            event.destination,
+            VsockAddr {
+                cid: guest_cid,
+                port: guest_port,
+            }
+        );
+        assert_eq!(event.event_type, VsockEventType::ConnectionRequest);
+        assert_eq!(
+            event.buffer_status,
+            VsockBufferStatus {
+                buffer_allocation: 50,
+                forward_count: 0,
             }
         );
 

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -469,8 +469,103 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
         self.driver.send(buffer, connection)
     }
 
-    // Polls the vsock device to receive data or other updates.
     pub fn poll(&self) -> Result<Option<VsockEvent>> {
+        let mut inner = self.inner.lock();
+        let local_cid = self.driver.local_cid();
+        let per_connection_buffer_capacity = inner.per_connection_buffer_capacity;
+
+        let result = self.driver.poll(|event, body| {
+            let connection = get_connection_for_event::<F>(&inner.connections, &event, local_cid);
+
+            // Skip events which don't match any connection we know about, unless they are a
+            // connection request.
+            let mut connection = if let Some((_, connection)) = connection {
+                connection
+            } else if let VsockEventType::ConnectionRequest = event.event_type {
+                // If the requested connection already exists or the CID isn't ours, ignore it.
+                if connection.is_some() || event.destination.cid != local_cid {
+                    return Ok(None);
+                }
+                drop(connection);
+                // Add the new connection to our list, at least for now. It will be removed again
+                // below if we weren't listening on the port.
+                inner.connections.push(F::Lock::new(Connection::new(
+                    event.source,
+                    event.destination.port,
+                    per_connection_buffer_capacity,
+                )));
+                inner.connections.last_mut().unwrap().lock()
+            } else {
+                return Ok(None);
+            };
+
+            // Update stored connection info.
+            connection.info.update_for_event(&event);
+
+            if let VsockEventType::Received { length } = event.event_type {
+                // Copy to buffer
+                if !connection.buffer.add(body) {
+                    return Err(SocketError::OutputBufferTooShort(length).into());
+                }
+            }
+
+            Ok(Some(event))
+        })?;
+
+        let Some(event) = result else {
+            return Ok(None);
+        };
+        // The connection must exist because we found it above in the callback.
+        let (connection_index, mut connection) =
+            get_connection_for_event::<F>(&inner.connections, &event, local_cid).unwrap();
+
+        match event.event_type {
+            VsockEventType::ConnectionRequest => {
+                if inner.listening_ports.contains(&event.destination.port) {
+                    self.driver.accept(connection.info.clone())?;
+                } else {
+                    // Reject the connection request and remove it from our list.
+                    self.driver.force_close(connection)?;
+                    inner.connections.swap_remove(connection_index);
+
+                    // No need to pass the request on to the client, as we've already rejected it.
+                    return Ok(None);
+                }
+            }
+            VsockEventType::Connected => {}
+            VsockEventType::Disconnected { reason } => {
+                // Wait until client reads all data before removing connection.
+                if connection.buffer.is_empty() {
+                    if reason == DisconnectReason::Shutdown {
+                        self.driver.force_close(connection)?;
+                    } else {
+                        // We need to drop `connection` before mutating the array.
+                        // `force_close` takes ownership of it on the other branch,
+                        // so we drop it explicitly here.
+                        drop(connection);
+                    }
+                    inner.connections.swap_remove(connection_index);
+                } else {
+                    connection.peer_requested_shutdown = true;
+                }
+            }
+            VsockEventType::Received { .. } => {
+                // Already copied the buffer in the callback above.
+            }
+            VsockEventType::CreditRequest => {
+                // If the peer requested credit, send an update.
+                self.driver.credit_update(connection)?;
+                // No need to pass the request on to the client, we've already handled it.
+                return Ok(None);
+            }
+            VsockEventType::CreditUpdate => {}
+        }
+
+        Ok(Some(event))
+    }
+
+    // Polls the vsock device to receive data or other updates.
+    pub fn poll_direct(&self) -> Result<Option<VsockEvent>> {
         let local_cid = self.driver.local_cid();
         let per_connection_buffer_capacity = self.inner.lock().per_connection_buffer_capacity;
         self.driver.poll(|mut event, body| {

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -30,7 +30,7 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 /// use virtio_drivers_and_devices::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
 ///
 /// # fn example<HalImpl: Hal, T: Transport>(transport: T) -> Result<(), Error> {
-/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _>::new(transport)?);
+/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _, _>::new(transport)?);
 ///
 /// // Start a thread to call `socket.poll()` and handle events.
 ///
@@ -51,11 +51,11 @@ pub struct VsockConnectionManager<
     T: Transport,
     L: LockFactory,
     const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
->(VsockConnectionManagerCommon<VirtIOSocket<H, T, RX_BUFFER_SIZE>, L>);
+>(VsockConnectionManagerCommon<VirtIOSocket<H, T, L, RX_BUFFER_SIZE>, L>);
 
 /// A high level interface for VirtIO socket (vsock) devices.
 pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: LockFactory>(
-    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T>, L>,
+    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T, L>, L>,
 );
 
 /// A trait defining shared behavior for VirtIO socket devices and drivers.
@@ -122,8 +122,7 @@ struct VsockConnectionManagerInner<L: LockFactory> {
 }
 
 struct VsockConnectionManagerCommon<M: VirtIOSocketManager, L: LockFactory> {
-    // TODO: remove the Lock here once VirtIOSocketManager is also thread-safe
-    driver: L::Lock<M>,
+    driver: M,
     inner: L::Lock<VsockConnectionManagerInner<L>>,
 }
 
@@ -152,18 +151,18 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
 {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
-    pub fn new(driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>) -> Self {
+    pub fn new(driver: VirtIOSocket<H, T, L, RX_BUFFER_SIZE>) -> Self {
         Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
     }
 
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver, with
     /// the given per-connection buffer capacity.
     pub fn new_with_capacity(
-        driver: VirtIOSocket<H, T, RX_BUFFER_SIZE>,
+        driver: VirtIOSocket<H, T, L, RX_BUFFER_SIZE>,
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
-            driver: L::Lock::new(driver),
+            driver,
             inner: L::Lock::new(VsockConnectionManagerInner {
                 connections: Vec::new(),
                 listening_ports: Vec::new(),
@@ -183,7 +182,6 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
     pub fn connect(&self, destination: VsockAddr, src_port: u32) -> Result {
-        let mut driver = self.0.driver.lock();
         let mut inner = self.0.inner.lock();
         if inner.connections.iter().any(|connection| {
             let connection = connection.lock();
@@ -195,7 +193,7 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
         let new_connection =
             Connection::new(destination, src_port, inner.per_connection_buffer_capacity);
 
-        driver.connect(&new_connection.info)?;
+        self.0.driver.connect(&new_connection.info)?;
         debug!("Connection requested: {:?}", new_connection.info);
         inner.connections.push(L::Lock::new(new_connection));
         Ok(())
@@ -261,18 +259,18 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
 
 impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionManager<H, T, L> {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
-    pub fn new(driver: VirtIOSocketDevice<H, T>) -> Self {
+    pub fn new(driver: VirtIOSocketDevice<H, T, L>) -> Self {
         Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
     }
 
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver, with
     /// the given per-connection buffer capacity.
     pub fn new_with_capacity(
-        driver: VirtIOSocketDevice<H, T>,
+        driver: VirtIOSocketDevice<H, T, L>,
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
-            driver: L::Lock::new(driver),
+            driver,
             inner: L::Lock::new(VsockConnectionManagerInner {
                 connections: Vec::new(),
                 listening_ports: Vec::new(),
@@ -371,10 +369,10 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
         Self::recv(self, peer, src_port, buffer)
     }
     unsafe fn ack_interrupt(&self) -> InterruptStatus {
-        let vsock_driver_ptr = self.0.driver.data_ptr();
+        let vsock_driver_ptr = (&raw const self.0.driver).cast_mut();
         // SAFETY: This function's safety requirements ensure that `self` points to a valid
         // VsockConnectionManager so this gives a valid pointer to the field.
-        unsafe { VirtIOSocket::<H, T, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
+        unsafe { VirtIOSocket::<H, T, L, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
     }
 }
 
@@ -429,21 +427,19 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
 
     /// Sends the buffer to the destination.
     pub fn send(&self, destination: VsockAddr, src_port: u32, buffer: &[u8]) -> Result {
-        let mut driver = self.driver.lock();
         let inner = self.inner.lock();
         let (_, mut connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        driver.send(buffer, &mut connection.info)
+        self.driver.send(buffer, &mut connection.info)
     }
 
     /// Polls the vsock device to receive data or other updates.
     pub fn poll(&self) -> Result<Option<VsockEvent>> {
-        let mut driver = self.driver.lock();
         let mut inner = self.inner.lock();
-        let local_cid = driver.local_cid();
+        let local_cid = self.driver.local_cid();
         let per_connection_buffer_capacity = inner.per_connection_buffer_capacity;
 
-        let result = driver.poll(|event, body| {
+        let result = self.driver.poll(|event, body| {
             let connection = get_connection_for_event::<L>(&inner.connections, &event, local_cid);
 
             // Skip events which don't match any connection we know about, unless they are a
@@ -492,10 +488,10 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         match event.event_type {
             VsockEventType::ConnectionRequest => {
                 if inner.listening_ports.contains(&event.destination.port) {
-                    driver.accept(&connection.info)?;
+                    self.driver.accept(&connection.info)?;
                 } else {
                     // Reject the connection request and remove it from our list.
-                    driver.force_close(&connection.info)?;
+                    self.driver.force_close(&connection.info)?;
                     drop(connection);
                     inner.connections.swap_remove(connection_index);
 
@@ -508,7 +504,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
                 // Wait until client reads all data before removing connection.
                 if connection.buffer.is_empty() {
                     if reason == DisconnectReason::Shutdown {
-                        driver.force_close(&connection.info)?;
+                        self.driver.force_close(&connection.info)?;
                     }
                     drop(connection);
                     inner.connections.swap_remove(connection_index);
@@ -521,7 +517,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
             }
             VsockEventType::CreditRequest => {
                 // If the peer requested credit, send an update.
-                driver.credit_update(&connection.info)?;
+                self.driver.credit_update(&connection.info)?;
                 // No need to pass the request on to the client, we've already handled it.
                 return Ok(None);
             }
@@ -533,12 +529,11 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
 
     /// Returns the local CID of the vsock device.
     pub fn local_cid(&self) -> u64 {
-        self.driver.lock().local_cid()
+        self.driver.local_cid()
     }
 
     /// Reads data received from the given connection.
     pub fn recv(&self, peer: VsockAddr, src_port: u32, buffer: &mut [u8]) -> Result<usize> {
-        let mut driver = self.driver.lock();
         let mut inner = self.inner.lock();
         let (connection_index, mut connection) =
             get_connection::<L>(&inner.connections, peer, src_port)?;
@@ -551,7 +546,7 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
         // If buffer is now empty and the peer requested shutdown, finish shutting down the
         // connection.
         if connection.peer_requested_shutdown && connection.buffer.is_empty() {
-            driver.force_close(&connection.info)?;
+            self.driver.force_close(&connection.info)?;
             drop(connection);
             inner.connections.swap_remove(connection_index);
         }
@@ -571,10 +566,9 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
 
     /// Sends a credit update to the given peer.
     pub fn update_credit(&self, peer: VsockAddr, src_port: u32) -> Result {
-        let mut driver = self.driver.lock();
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, peer, src_port)?;
-        driver.credit_update(&connection.info)
+        self.driver.credit_update(&connection.info)
     }
 
     /// Blocks until we get some event from the vsock device.
@@ -595,20 +589,18 @@ impl<M: VirtIOSocketManager, L: LockFactory> VsockConnectionManagerCommon<M, L> 
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
     pub fn shutdown(&self, destination: VsockAddr, src_port: u32) -> Result {
-        let mut driver = self.driver.lock();
         let inner = self.inner.lock();
         let (_, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        driver.shutdown(&connection.info)
+        self.driver.shutdown(&connection.info)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
     pub fn force_close(&self, destination: VsockAddr, src_port: u32) -> Result {
-        let mut driver = self.driver.lock();
         let mut inner = self.inner.lock();
         let (index, connection) = get_connection::<L>(&inner.connections, destination, src_port)?;
 
-        driver.force_close(&connection.info)?;
+        self.driver.force_close(&connection.info)?;
         drop(connection);
 
         inner.connections.swap_remove(index);

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -122,12 +122,17 @@ pub trait VsockManager: Send + Sync {
     /// as from an interrupt handler. It may only be called on the driver side as it will panic if
     /// called on the device side.
     ///
+    /// This takes a raw `*mut Self` rather than `&self` because acknowledging the interrupt mutates
+    /// the underlying transport, which is a plain field, not behind an `UnsafeCell` or a lock.
+    /// Writing through a pointer derived from a shared `&self` reference to such a field is undefined
+    /// behavior regardless of runtime exclusivity, so the caller must supply a pointer whose
+    /// provenance permits the write.
+    ///
     /// # Safety
     ///
-    /// The implementation may acknowledge the interrupt through a raw pointer derived from `&self`,
-    /// mutating the underlying transport. The caller must ensure that no other references to the
-    /// driver or its transport are concurrently active for the duration of this call.
-    unsafe fn ack_interrupt(&self) -> InterruptStatus;
+    /// `ptr` must point to an initialized VsockManager impl which is ready to acknowledge interrupts,
+    /// and no other references to it or its transport may be active for the duration of the call.
+    unsafe fn ack_interrupt(ptr: *mut Self) -> InterruptStatus;
 }
 
 struct VsockConnectionManagerInner<L: LockFactory> {
@@ -457,10 +462,11 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
     fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         Self::recv_buffer_available_bytes(self, peer, src_port)
     }
-    unsafe fn ack_interrupt(&self) -> InterruptStatus {
-        let vsock_driver_ptr = (&raw const self.0.driver).cast_mut();
-        // SAFETY: This function's safety requirements ensure that `self` points to a valid
+    unsafe fn ack_interrupt(ptr: *mut Self) -> InterruptStatus {
+        // SAFETY: This function's safety requirements ensure that `ptr` points to a valid
         // VsockConnectionManager so this gives a valid pointer to the field.
+        let vsock_driver_ptr = unsafe { &raw mut (*ptr).0.driver };
+        // SAFETY: delegated to the caller.
         unsafe { VirtIOSocket::<H, T, L, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
     }
 }
@@ -504,7 +510,7 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
     fn recv_buffer_available_bytes(&self, peer: VsockAddr, src_port: u32) -> Result<usize> {
         Self::recv_buffer_available_bytes(self, peer, src_port)
     }
-    unsafe fn ack_interrupt(&self) -> InterruptStatus {
+    unsafe fn ack_interrupt(_ptr: *mut Self) -> InterruptStatus {
         panic!("vsock devices cannot acknowledge interrupts")
     }
 }

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -627,14 +627,15 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
                 return Ok(None);
             }
             let inner_guard = self.inner.lock();
-            if !inner_guard
-                .listening_ports
-                .contains(&event.destination.port)
-            {
-                // TODO: Return reject connection action here instead
-                return Ok(None);
-            }
             if event.event_type == VsockEventType::ConnectionRequest {
+                if !inner_guard
+                    .listening_ports
+                    .contains(&event.destination.port)
+                {
+                    // TODO: Return reject connection action here instead
+                    return Ok(None);
+                }
+
                 let mut c = Connection::new(
                     event.source,
                     event.destination.port,

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -1,5 +1,5 @@
 use super::{
-    protocol::VsockAddr, vsock::ConnectionInfo, DisconnectReason, SocketError, VirtIOSocket,
+    protocol::VsockAddr, vsock::ConnectionInfo, SocketError, VirtIOSocket,
     VirtIOSocketDevice, VirtIOSocketManager, VsockEvent, VsockEventType, DEFAULT_RX_BUFFER_SIZE,
 };
 use crate::{
@@ -126,8 +126,9 @@ struct VsockConnectionManagerCommon<M: VirtIOSocketManager<L::Lock<Connection>>,
     inner: L::Lock<VsockConnectionManagerInner<L>>,
 }
 
+/// The state of a single vsock connection managed by a [`VsockConnectionManager`].
 #[derive(Debug)]
-pub(crate) struct Connection {
+pub struct Connection {
     pub(crate) info: ConnectionInfo,
     buffer: RingBuffer,
     /// The peer sent a SHUTDOWN request, but we haven't yet responded with a RST because there is
@@ -436,101 +437,53 @@ impl<M: VirtIOSocketManager<L::Lock<Connection>>, L: LockFactory>
         self.driver.send(buffer, connection)
     }
 
-    /// Polls the vsock device to receive data or other updates.
+    // Polls the vsock device to receive data or other updates.
     pub fn poll(&self) -> Result<Option<VsockEvent>> {
-        let mut inner = self.inner.lock();
         let local_cid = self.driver.local_cid();
-        let per_connection_buffer_capacity = inner.per_connection_buffer_capacity;
-
-        let result = self.driver.poll(|event, body| {
-            let connection = get_connection_for_event::<L>(&inner.connections, &event, local_cid);
-
-            // Skip events which don't match any connection we know about, unless they are a
-            // connection request.
-            let mut connection = if let Some((_, connection)) = connection {
-                connection
-            } else if let VsockEventType::ConnectionRequest = event.event_type {
-                // If the requested connection already exists or the CID isn't ours, ignore it.
-                if connection.is_some() || event.destination.cid != local_cid {
-                    return Ok(None);
-                }
-                drop(connection);
-                // Add the new connection to our list, at least for now. It will be removed again
-                // below if we weren't listening on the port.
-                inner.connections.push(L::Lock::new(Connection::new(
+        let per_connection_buffer_capacity = self.inner.lock().per_connection_buffer_capacity;
+        self.driver.poll(|mut event, body| {
+            if event.destination.cid != local_cid {
+                return Ok(None);
+            }
+            let inner_guard = self.inner.lock();
+            if !inner_guard
+                .listening_ports
+                .contains(&event.destination.port)
+            {
+                // TODO: Return reject connection action here instead
+                return Ok(None);
+            }
+            if event.event_type == VsockEventType::ConnectionRequest {
+                let mut c = Connection::new(
                     event.source,
                     event.destination.port,
                     per_connection_buffer_capacity,
-                )));
-                inner.connections.last_mut().unwrap().lock()
-            } else {
+                );
+                c.info.update_for_event(&event);
+                event.new_connection = Some(c);
+                // TODO: We deliberately do not add the connection to `inner.connections` until the
+                // caller accepts the connection. This means that if the peer follows up with a
+                // reset packet before the connection is accepted, it will be treated as an
+                // unknown connection.
+                return Ok(Some(event));
+            }
+            let existing_connection =
+                get_connection_for_event::<L>(&inner_guard.connections, &event, local_cid);
+            if existing_connection.is_none() {
                 return Ok(None);
-            };
-
-            // Update stored connection info.
-            connection.info.update_for_event(&event);
+            }
+            let mut existing_connection = existing_connection.unwrap().1;
+            existing_connection.info.update_for_event(&event);
 
             if let VsockEventType::Received { length } = event.event_type {
                 // Copy to buffer
-                if !connection.buffer.add(body) {
+                if !existing_connection.buffer.add(body) {
                     return Err(SocketError::OutputBufferTooShort(length).into());
                 }
             }
 
             Ok(Some(event))
-        })?;
-
-        let Some(event) = result else {
-            return Ok(None);
-        };
-
-        // The connection must exist because we found it above in the callback.
-        let (connection_index, mut connection) =
-            get_connection_for_event::<L>(&inner.connections, &event, local_cid).unwrap();
-
-        match event.event_type {
-            VsockEventType::ConnectionRequest => {
-                if inner.listening_ports.contains(&event.destination.port) {
-                    self.driver.accept(connection)?;
-                } else {
-                    // Reject the connection request and remove it from our list.
-                    self.driver.force_close(connection)?;
-                    inner.connections.swap_remove(connection_index);
-
-                    // No need to pass the request on to the client, as we've already rejected it.
-                    return Ok(None);
-                }
-            }
-            VsockEventType::Connected => {}
-            VsockEventType::Disconnected { reason } => {
-                // Wait until client reads all data before removing connection.
-                if connection.buffer.is_empty() {
-                    if reason == DisconnectReason::Shutdown {
-                        self.driver.force_close(connection)?;
-                    } else {
-                        // We need to drop `connection` before mutating the array.
-                        // `force_close` takes ownership of it on the other branch,
-                        // so we drop it explicitly here.
-                        drop(connection);
-                    }
-                    inner.connections.swap_remove(connection_index);
-                } else {
-                    connection.peer_requested_shutdown = true;
-                }
-            }
-            VsockEventType::Received { .. } => {
-                // Already copied the buffer in the callback above.
-            }
-            VsockEventType::CreditRequest => {
-                // If the peer requested credit, send an update.
-                self.driver.credit_update(connection)?;
-                // No need to pass the request on to the client, we've already handled it.
-                return Ok(None);
-            }
-            VsockEventType::CreditUpdate => {}
-        }
-
-        Ok(Some(event))
+        })
     }
 
     /// Returns the local CID of the vsock device.

--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -638,7 +638,7 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
             if event.destination.cid != local_cid {
                 return Ok(None);
             }
-            let inner_guard = self.inner.lock();
+            let mut inner_guard = self.inner.lock();
             if event.event_type == VsockEventType::ConnectionRequest {
                 if !inner_guard
                     .listening_ports
@@ -661,11 +661,19 @@ impl<M: VirtIOSocketManager<L>, L: LockFactory> VsockConnectionManagerCommon<M, 
                 // unknown connection.
                 return Ok(Some(event));
             }
-            let Some((_, existing_connection)) =
+            let Some((connection_index, existing_connection)) =
                 get_connection_for_event::<L>(&inner_guard.connections, &event, local_cid)
             else {
                 return Ok(None);
             };
+            if let VsockEventType::Disconnected {
+                reason: DisconnectReason::Reset,
+            } = event.event_type
+            {
+                // Remove the connection immediately
+                inner_guard.connections.swap_remove(connection_index);
+                return Ok(Some(event));
+            }
             drop(inner_guard);
 
             let mut existing_connection = existing_connection.lock();

--- a/src/device/socket/mod.rs
+++ b/src/device/socket/mod.rs
@@ -15,7 +15,9 @@ mod protocol;
 mod vsock;
 
 #[cfg(feature = "alloc")]
-pub use connectionmanager::{VsockConnectionManager, VsockDeviceConnectionManager, VsockManager};
+pub use connectionmanager::{
+    Connection, VsockConnectionManager, VsockDeviceConnectionManager, VsockManager,
+};
 pub use error::SocketError;
 pub use protocol::{StreamShutdown, VsockAddr, VMADDR_CID_HOST};
 #[cfg(feature = "alloc")]

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -11,7 +11,7 @@ use crate::config::read_config;
 use crate::hal::{DeviceHal, Hal};
 use crate::queue::{owning::OwningQueue, DeviceVirtQueue, VirtQueue};
 use crate::transport::{DeviceTransport, InterruptStatus, Transport};
-use crate::Result;
+use crate::{Lock, LockFactory, Result};
 use core::mem::size_of;
 use log::debug;
 use zerocopy::{FromBytes, IntoBytes};
@@ -219,21 +219,21 @@ pub enum VsockEventType {
 ///
 /// `RX_BUFFER_SIZE` is the size in bytes of each buffer used in the RX virtqueue. This must be
 /// bigger than `size_of::<VirtioVsockHdr>()`.
-pub struct VirtIOSocket<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE>
+pub struct VirtIOSocket<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE>
 {
     transport: T,
     /// Virtqueue to receive packets.
-    rx: OwningQueue<H, QUEUE_SIZE, RX_BUFFER_SIZE>,
-    tx: VirtQueue<H, { QUEUE_SIZE }>,
+    rx: L::Lock<OwningQueue<H, QUEUE_SIZE, RX_BUFFER_SIZE>>,
+    tx: L::Lock<VirtQueue<H, { QUEUE_SIZE }>>,
     /// Virtqueue to receive events from the device.
-    event: VirtQueue<H, { QUEUE_SIZE }>,
+    event: L::Lock<VirtQueue<H, { QUEUE_SIZE }>>,
     /// The guest_cid field contains the guest’s context ID, which uniquely identifies
     /// the device for its lifetime. The upper 32 bits of the CID are reserved and zeroed.
     guest_cid: u64,
 }
 
-impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> Drop
-    for VirtIOSocket<H, T, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> Drop
+    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
 {
     fn drop(&mut self) {
         // Clear any pointers pointing to DMA regions, so the device doesn't try to access them
@@ -244,7 +244,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> Drop
     }
 }
 
-impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BUFFER_SIZE> {
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, L, RX_BUFFER_SIZE> {
     /// Create a new VirtIO Vsock driver.
     pub fn new(mut transport: T) -> Result<Self> {
         assert!(RX_BUFFER_SIZE > size_of::<VirtioVsockHdr>());
@@ -287,9 +287,9 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
 
         Ok(Self {
             transport,
-            rx,
-            tx,
-            event,
+            rx: L::Lock::new(rx),
+            tx: L::Lock::new(tx),
+            event: L::Lock::new(event),
             guest_cid,
         })
     }
@@ -304,7 +304,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
-    pub fn connect(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn connect(&self, connection_info: &ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Request.into(),
             ..connection_info.new_header(self.guest_cid)
@@ -315,29 +315,29 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     }
 
     /// Accepts the given connection from a peer.
-    pub fn accept(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn accept(&self, connection_info: &ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::accept(self, connection_info)
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    pub fn request_credit(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn request_credit(&self, connection_info: &ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::request_credit(self, connection_info)
     }
 
     /// Sends the buffer to the destination.
-    pub fn send(&mut self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
+    pub fn send(&self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::send(self, buffer, connection_info)
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    pub fn credit_update(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn credit_update(&self, connection_info: &ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::credit_update(self, connection_info)
     }
 
     /// Polls the RX virtqueue for the next event, and calls the given handler function to handle
     /// it.
     pub fn poll(
-        &mut self,
+        &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
         <Self as VirtIOSocketManager>::poll(self, handler)
@@ -350,7 +350,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
     pub fn shutdown_with_hints(
-        &mut self,
+        &self,
         connection_info: &ConnectionInfo,
         hints: StreamShutdown,
     ) -> Result {
@@ -363,22 +363,26 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn shutdown(&self, connection_info: &ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::shutdown(self, connection_info)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub fn force_close(&mut self, connection_info: &ConnectionInfo) -> Result {
+    pub fn force_close(&self, connection_info: &ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager>::force_close(self, connection_info)
     }
 
-    fn send_packet_to_tx_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
+    fn send_packet_to_tx_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
         let _len = if buffer.is_empty() {
             self.tx
+                .lock()
                 .add_notify_wait_pop(&[header.as_bytes()], &mut [], &self.transport)?
         } else {
-            self.tx
-                .add_notify_wait_pop(&[header.as_bytes(), buffer], &mut [], &self.transport)?
+            self.tx.lock().add_notify_wait_pop(
+                &[header.as_bytes(), buffer],
+                &mut [],
+                &self.transport,
+            )?
         };
         Ok(())
     }
@@ -399,20 +403,20 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     }
 }
 
-impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
-    for VirtIOSocket<H, T, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
+    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
 {
     fn local_cid(&self) -> u64 {
         self.guest_cid()
     }
-    fn send_packet_to_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
+    fn send_packet_to_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
         self.send_packet_to_tx_queue(header, buffer)
     }
     fn poll(
-        &mut self,
+        &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        self.rx.poll(&self.transport, |buffer| {
+        self.rx.lock().poll(&self.transport, |buffer| {
             let (header, body) = read_header_and_body(buffer)?;
             VsockEvent::from_header(&header).and_then(|event| handler(event, body))
         })
@@ -420,14 +424,14 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
 }
 
 /// A low-level interface for a vsock device implementation
-pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport> {
+pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport, L: LockFactory> {
     transport: T,
-    rx: DeviceVirtQueue<H, { QUEUE_SIZE }>,
-    tx: DeviceVirtQueue<H, { QUEUE_SIZE }>,
-    event: DeviceVirtQueue<H, { QUEUE_SIZE }>,
+    rx: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
+    tx: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
+    event: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
 }
 
-impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketDevice<H, T> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketDevice<H, T, L> {
     /// Create a new VirtIO Vsock device.
     pub fn new(mut transport: T) -> Result<Self> {
         let rx = DeviceVirtQueue::new(&mut transport, RX_QUEUE_IDX)?;
@@ -435,32 +439,34 @@ impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketDevice<H, T> {
         let event = DeviceVirtQueue::new(&mut transport, EVENT_QUEUE_IDX)?;
         Ok(Self {
             transport,
-            rx,
-            tx,
-            event,
+            rx: L::Lock::new(rx),
+            tx: L::Lock::new(tx),
+            event: L::Lock::new(event),
         })
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketManager for VirtIOSocketDevice<H, T> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager for VirtIOSocketDevice<H, T, L> {
     fn local_cid(&self) -> u64 {
         VMADDR_CID_HOST
     }
-    fn send_packet_to_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
+    fn send_packet_to_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
         if buffer.is_empty() {
             self.rx
+                .lock()
                 .wait_pop_add_notify(&[header.as_bytes()], &self.transport)?
         } else {
             self.rx
+                .lock()
                 .wait_pop_add_notify(&[header.as_bytes(), buffer], &self.transport)?
         }
         Ok(())
     }
     fn poll(
-        &mut self,
+        &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        self.tx.poll(&self.transport, |buffer| {
+        self.tx.lock().poll(&self.transport, |buffer| {
             let (header, body) = read_header_and_body(buffer)?;
             VsockEvent::from_header(&header).and_then(|event| handler(event, body))
         })
@@ -468,14 +474,14 @@ impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketManager for VirtIOSocketDevic
 }
 pub trait VirtIOSocketManager: Send {
     fn local_cid(&self) -> u64;
-    fn send_packet_to_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result;
+    fn send_packet_to_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result;
     fn poll(
-        &mut self,
+        &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>>;
 
     /// Accepts the given connection from a peer.
-    fn accept(&mut self, connection_info: &ConnectionInfo) -> Result {
+    fn accept(&self, connection_info: &ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Response.into(),
             ..connection_info.new_header(self.local_cid())
@@ -484,7 +490,7 @@ pub trait VirtIOSocketManager: Send {
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    fn request_credit(&mut self, connection_info: &ConnectionInfo) -> Result {
+    fn request_credit(&self, connection_info: &ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditRequest.into(),
             ..connection_info.new_header(self.local_cid())
@@ -493,7 +499,7 @@ pub trait VirtIOSocketManager: Send {
     }
 
     /// Sends the buffer to the destination.
-    fn send(&mut self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
+    fn send(&self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
         self.check_peer_buffer_is_sufficient(connection_info, buffer.len())?;
 
         let len = buffer.len() as u32;
@@ -507,7 +513,7 @@ pub trait VirtIOSocketManager: Send {
     }
 
     fn check_peer_buffer_is_sufficient(
-        &mut self,
+        &self,
         connection_info: &mut ConnectionInfo,
         buffer_len: usize,
     ) -> Result {
@@ -525,7 +531,7 @@ pub trait VirtIOSocketManager: Send {
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    fn credit_update(&mut self, connection_info: &ConnectionInfo) -> Result {
+    fn credit_update(&self, connection_info: &ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditUpdate.into(),
             ..connection_info.new_header(self.local_cid())
@@ -540,7 +546,7 @@ pub trait VirtIOSocketManager: Send {
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
     fn shutdown_with_hints(
-        &mut self,
+        &self,
         connection_info: &ConnectionInfo,
         hints: StreamShutdown,
     ) -> Result {
@@ -558,7 +564,7 @@ pub trait VirtIOSocketManager: Send {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown(&mut self, connection_info: &ConnectionInfo) -> Result {
+    fn shutdown(&self, connection_info: &ConnectionInfo) -> Result {
         self.shutdown_with_hints(
             connection_info,
             StreamShutdown::SEND | StreamShutdown::RECEIVE,
@@ -566,7 +572,7 @@ pub trait VirtIOSocketManager: Send {
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    fn force_close(&mut self, connection_info: &ConnectionInfo) -> Result {
+    fn force_close(&self, connection_info: &ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Rst.into(),
             ..connection_info.new_header(self.local_cid())

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -469,7 +469,7 @@ impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketManager for VirtIOSocketDevic
         })
     }
 }
-pub trait VirtIOSocketManager {
+pub trait VirtIOSocketManager: Send {
     fn local_cid(&self) -> u64;
     fn send_packet_to_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result;
     fn poll(

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -13,6 +13,7 @@ use crate::hal::{DeviceHal, Hal};
 use crate::queue::{owning::OwningQueue, DeviceVirtQueue, VirtQueue};
 use crate::transport::{DeviceTransport, InterruptStatus, Transport};
 use crate::{Lock, LockFactory, Result};
+use alloc::sync::Arc;
 use core::mem::size_of;
 use log::debug;
 use zerocopy::{FromBytes, IntoBytes};
@@ -315,15 +316,14 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
-    pub(crate) fn connect(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
+    pub fn connect(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        let connection = connection.lock();
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Request.into(),
             ..connection.info.new_header(self.guest_cid)
         };
         drop(connection);
+
         // Sends a header only packet to the TX queue to connect the device to the listening socket
         // at the given destination.
         self.send_packet_to_tx_queue(&header, &[])
@@ -331,32 +331,22 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
 
     /// Accepts the given connection from a peer.
     pub fn accept(&self, connection: ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::accept(self, connection)
+        <Self as VirtIOSocketManager<L>>::accept(self, connection)
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    pub(crate) fn request_credit(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::request_credit(self, connection)
+    pub fn request_credit(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        <Self as VirtIOSocketManager<L>>::request_credit(self, connection)
     }
 
     /// Sends the buffer to the destination.
-    pub(crate) fn send(
-        &self,
-        buffer: &[u8],
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::send(self, buffer, connection)
+    pub fn send(&self, buffer: &[u8], connection: Arc<L::Lock<Connection>>) -> Result {
+        <Self as VirtIOSocketManager<L>>::send(self, buffer, connection)
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    pub(crate) fn credit_update(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::credit_update(self, connection)
+    pub fn credit_update(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        <Self as VirtIOSocketManager<L>>::credit_update(self, connection)
     }
 
     /// Polls the RX virtqueue for the next event, and calls the given handler function to handle
@@ -365,7 +355,7 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
         &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::poll(self, handler)
+        <Self as VirtIOSocketManager<L>>::poll(self, handler)
     }
 
     /// Requests to shut down the connection cleanly, sending hints about whether we will send or
@@ -376,12 +366,10 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// shutdown.
     pub(crate) fn shutdown_with_hints(
         &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+        connection: Arc<L::Lock<Connection>>,
         hints: StreamShutdown,
     ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::shutdown_with_hints(
-            self, connection, hints,
-        )
+        <Self as VirtIOSocketManager<L>>::shutdown_with_hints(self, connection, hints)
     }
 
     /// Requests to shut down the connection cleanly, telling the peer that we won't send or receive
@@ -390,19 +378,13 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub(crate) fn shutdown(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::shutdown(self, connection)
+    pub fn shutdown(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        <Self as VirtIOSocketManager<L>>::shutdown(self, connection)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub(crate) fn force_close(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
-        <Self as VirtIOSocketManager<L::Lock<Connection>>>::force_close(self, connection)
+    pub fn force_close(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        <Self as VirtIOSocketManager<L>>::force_close(self, connection)
     }
 
     fn send_packet_to_tx_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
@@ -436,8 +418,8 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
-    VirtIOSocketManager<L::Lock<Connection>> for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocketManager<L>
+    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
 {
     fn local_cid(&self) -> u64 {
         self.guest_cid()
@@ -479,7 +461,7 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketDevice<H, T, 
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager<L::Lock<Connection>>
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager<L>
     for VirtIOSocketDevice<H, T, L>
 {
     fn local_cid(&self) -> u64 {
@@ -507,10 +489,7 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager<L::Lo
         })
     }
 }
-pub trait VirtIOSocketManager<L>: Send
-where
-    L: Lock<Connection>,
-{
+pub trait VirtIOSocketManager<L: LockFactory>: Send {
     fn local_cid(&self) -> u64;
     fn send_packet_to_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result;
     fn poll(
@@ -528,19 +507,22 @@ where
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    fn request_credit(&self, connection: L::Guard<'_>) -> Result {
+    fn request_credit(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        let connection = connection.lock();
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditRequest.into(),
             ..connection.info.new_header(self.local_cid())
         };
         drop(connection);
+
         self.send_packet_to_queue(&header, &[])
     }
 
     /// Sends the buffer to the destination.
-    fn send(&self, buffer: &[u8], connection: L::Guard<'_>) -> Result {
-        let mut connection = self.check_peer_buffer_is_sufficient(connection, buffer.len())?;
+    fn send(&self, buffer: &[u8], connection: Arc<L::Lock<Connection>>) -> Result {
+        let connection = self.check_peer_buffer_is_sufficient(connection, buffer.len())?;
 
+        let mut connection = connection.lock();
         let len = buffer.len() as u32;
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Rw.into(),
@@ -555,16 +537,19 @@ where
 
     fn check_peer_buffer_is_sufficient<'a>(
         &self,
-        mut connection: L::Guard<'a>,
+        connection: Arc<L::Lock<Connection>>,
         buffer_len: usize,
-    ) -> Result<L::Guard<'a>> {
-        if connection.info.peer_free() as usize >= buffer_len {
+    ) -> Result<Arc<L::Lock<Connection>>> {
+        let mut connection_guard = connection.lock();
+        if connection_guard.info.peer_free() as usize >= buffer_len {
+            drop(connection_guard);
             Ok(connection)
         } else {
             // Request an update of the cached peer credit, if we haven't already done so, and tell
             // the caller to try again later.
-            if !connection.info.has_pending_credit_request {
-                connection.info.has_pending_credit_request = true;
+            if !connection_guard.info.has_pending_credit_request {
+                connection_guard.info.has_pending_credit_request = true;
+                drop(connection_guard);
                 self.request_credit(connection)?;
             }
             Err(SocketError::InsufficientBufferSpaceInPeer.into())
@@ -572,12 +557,14 @@ where
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    fn credit_update(&self, connection: L::Guard<'_>) -> Result {
+    fn credit_update(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        let connection = connection.lock();
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditUpdate.into(),
             ..connection.info.new_header(self.local_cid())
         };
         drop(connection);
+
         self.send_packet_to_queue(&header, &[])
     }
 
@@ -587,13 +574,19 @@ where
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown_with_hints(&self, connection: L::Guard<'_>, hints: StreamShutdown) -> Result {
+    fn shutdown_with_hints(
+        &self,
+        connection: Arc<L::Lock<Connection>>,
+        hints: StreamShutdown,
+    ) -> Result {
+        let connection = connection.lock();
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Shutdown.into(),
             flags: hints.into(),
             ..connection.info.new_header(self.local_cid())
         };
         drop(connection);
+
         self.send_packet_to_queue(&header, &[])
     }
 
@@ -603,17 +596,19 @@ where
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown(&self, connection: L::Guard<'_>) -> Result {
+    fn shutdown(&self, connection: Arc<L::Lock<Connection>>) -> Result {
         self.shutdown_with_hints(connection, StreamShutdown::SEND | StreamShutdown::RECEIVE)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    fn force_close(&self, connection: L::Guard<'_>) -> Result {
+    fn force_close(&self, connection: Arc<L::Lock<Connection>>) -> Result {
+        let connection = connection.lock();
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Rst.into(),
             ..connection.info.new_header(self.local_cid())
         };
         drop(connection);
+
         self.send_packet_to_queue(&header, &[])?;
         Ok(())
     }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -330,10 +330,7 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     }
 
     /// Accepts the given connection from a peer.
-    pub(crate) fn accept(
-        &self,
-        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
-    ) -> Result {
+    pub fn accept(&self, connection: ConnectionInfo) -> Result {
         <Self as VirtIOSocketManager<L::Lock<Connection>>>::accept(self, connection)
     }
 
@@ -522,12 +519,11 @@ where
     ) -> Result<Option<VsockEvent>>;
 
     /// Accepts the given connection from a peer.
-    fn accept(&self, connection: L::Guard<'_>) -> Result {
+    fn accept(&self, info: ConnectionInfo) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Response.into(),
-            ..connection.info.new_header(self.local_cid())
+            ..info.new_header(self.local_cid())
         };
-        drop(connection);
         self.send_packet_to_queue(&header, &[])
     }
 

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -537,7 +537,10 @@ pub trait VirtIOSocketManager<L: LockFactory>: Send {
             if !connection_guard.info.has_pending_credit_request {
                 connection_guard.info.has_pending_credit_request = true;
                 drop(connection_guard);
-                self.request_credit(connection)?;
+                if let Err(e) = self.request_credit(connection.clone()) {
+                    connection.lock().info.has_pending_credit_request = false;
+                    return Err(e);
+                }
             }
             return Err(SocketError::InsufficientBufferSpaceInPeer.into());
         }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -103,7 +103,7 @@ impl ConnectionInfo {
 }
 
 /// An event received from a VirtIO socket device.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct VsockEvent {
     /// The source of the event, i.e. the peer who sent it.
     pub source: VsockAddr,
@@ -113,6 +113,9 @@ pub struct VsockEvent {
     pub buffer_status: VsockBufferStatus,
     /// The type of event.
     pub event_type: VsockEventType,
+
+    /// The new connection, if this event is a connection request.
+    pub new_connection: Option<Connection>,
 }
 
 impl VsockEvent {
@@ -170,6 +173,7 @@ impl VsockEvent {
             destination,
             buffer_status,
             event_type,
+            new_connection: None,
         })
     }
 }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -633,7 +633,7 @@ fn read_header_and_body(buffer: &[u8]) -> Result<(VirtioVsockHdr, &[u8])> {
     Ok((header, data))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "spin"))]
 mod tests {
     use super::*;
     use crate::{
@@ -643,6 +643,7 @@ mod tests {
             fake::{FakeTransport, QueueStatus, State},
             DeviceType,
         },
+        SpinLockFactory,
     };
     use alloc::{sync::Arc, vec};
     use std::sync::Mutex;
@@ -668,7 +669,10 @@ mod tests {
             state: state.clone(),
         };
         let socket =
-            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>>::new(transport).unwrap();
+            VirtIOSocket::<FakeHal, FakeTransport<VirtioVsockConfig>, SpinLockFactory>::new(
+                transport,
+            )
+            .unwrap();
         assert_eq!(socket.guest_cid(), 0x00_0000_0042);
     }
 }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -1,6 +1,7 @@
 //! Driver for VirtIO socket devices.
 #![deny(unsafe_op_in_unsafe_fn)]
 
+use super::connectionmanager::Connection;
 use super::error::SocketError;
 use super::protocol::{
     Feature, StreamShutdown, VirtioVsockConfig, VirtioVsockHdr, VirtioVsockOp, VsockAddr,
@@ -219,8 +220,12 @@ pub enum VsockEventType {
 ///
 /// `RX_BUFFER_SIZE` is the size in bytes of each buffer used in the RX virtqueue. This must be
 /// bigger than `size_of::<VirtioVsockHdr>()`.
-pub struct VirtIOSocket<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE>
-{
+pub struct VirtIOSocket<
+    H: Hal,
+    T: Transport,
+    L: LockFactory,
+    const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
+> {
     transport: T,
     /// Virtqueue to receive packets.
     rx: L::Lock<OwningQueue<H, QUEUE_SIZE, RX_BUFFER_SIZE>>,
@@ -244,7 +249,9 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> Drop
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, L, RX_BUFFER_SIZE> {
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
+    VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+{
     /// Create a new VirtIO Vsock driver.
     pub fn new(mut transport: T) -> Result<Self> {
         assert!(RX_BUFFER_SIZE > size_of::<VirtioVsockHdr>());
@@ -304,34 +311,51 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Connected` event indicating that the peer has accepted the connection
     /// before sending data.
-    pub fn connect(&self, connection_info: &ConnectionInfo) -> Result {
+    pub(crate) fn connect(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Request.into(),
-            ..connection_info.new_header(self.guest_cid)
+            ..connection.info.new_header(self.guest_cid)
         };
+        drop(connection);
         // Sends a header only packet to the TX queue to connect the device to the listening socket
         // at the given destination.
         self.send_packet_to_tx_queue(&header, &[])
     }
 
     /// Accepts the given connection from a peer.
-    pub fn accept(&self, connection_info: &ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::accept(self, connection_info)
+    pub(crate) fn accept(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::accept(self, connection)
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    pub fn request_credit(&self, connection_info: &ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::request_credit(self, connection_info)
+    pub(crate) fn request_credit(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::request_credit(self, connection)
     }
 
     /// Sends the buffer to the destination.
-    pub fn send(&self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::send(self, buffer, connection_info)
+    pub(crate) fn send(
+        &self,
+        buffer: &[u8],
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::send(self, buffer, connection)
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    pub fn credit_update(&self, connection_info: &ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::credit_update(self, connection_info)
+    pub(crate) fn credit_update(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::credit_update(self, connection)
     }
 
     /// Polls the RX virtqueue for the next event, and calls the given handler function to handle
@@ -340,7 +364,7 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
         &self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        <Self as VirtIOSocketManager>::poll(self, handler)
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::poll(self, handler)
     }
 
     /// Requests to shut down the connection cleanly, sending hints about whether we will send or
@@ -349,12 +373,14 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown_with_hints(
+    pub(crate) fn shutdown_with_hints(
         &self,
-        connection_info: &ConnectionInfo,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
         hints: StreamShutdown,
     ) -> Result {
-        <Self as VirtIOSocketManager>::shutdown_with_hints(self, connection_info, hints)
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::shutdown_with_hints(
+            self, connection, hints,
+        )
     }
 
     /// Requests to shut down the connection cleanly, telling the peer that we won't send or receive
@@ -363,13 +389,19 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    pub fn shutdown(&self, connection_info: &ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::shutdown(self, connection_info)
+    pub(crate) fn shutdown(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::shutdown(self, connection)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    pub fn force_close(&self, connection_info: &ConnectionInfo) -> Result {
-        <Self as VirtIOSocketManager>::force_close(self, connection_info)
+    pub(crate) fn force_close(
+        &self,
+        connection: <L::Lock<Connection> as Lock<Connection>>::Guard<'_>,
+    ) -> Result {
+        <Self as VirtIOSocketManager<L::Lock<Connection>>>::force_close(self, connection)
     }
 
     fn send_packet_to_tx_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
@@ -403,8 +435,8 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
-    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
+    VirtIOSocketManager<L::Lock<Connection>> for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
 {
     fn local_cid(&self) -> u64 {
         self.guest_cid()
@@ -446,7 +478,9 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketDevice<H, T, 
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager for VirtIOSocketDevice<H, T, L> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager<L::Lock<Connection>>
+    for VirtIOSocketDevice<H, T, L>
+{
     fn local_cid(&self) -> u64 {
         VMADDR_CID_HOST
     }
@@ -472,7 +506,10 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager for V
         })
     }
 }
-pub trait VirtIOSocketManager: Send {
+pub trait VirtIOSocketManager<L>: Send
+where
+    L: Lock<Connection>,
+{
     fn local_cid(&self) -> u64;
     fn send_packet_to_queue(&self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result;
     fn poll(
@@ -481,61 +518,66 @@ pub trait VirtIOSocketManager: Send {
     ) -> Result<Option<VsockEvent>>;
 
     /// Accepts the given connection from a peer.
-    fn accept(&self, connection_info: &ConnectionInfo) -> Result {
+    fn accept(&self, connection: L::Guard<'_>) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Response.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
+        drop(connection);
         self.send_packet_to_queue(&header, &[])
     }
 
     /// Requests the peer to send us a credit update for the given connection.
-    fn request_credit(&self, connection_info: &ConnectionInfo) -> Result {
+    fn request_credit(&self, connection: L::Guard<'_>) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditRequest.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
+        drop(connection);
         self.send_packet_to_queue(&header, &[])
     }
 
     /// Sends the buffer to the destination.
-    fn send(&self, buffer: &[u8], connection_info: &mut ConnectionInfo) -> Result {
-        self.check_peer_buffer_is_sufficient(connection_info, buffer.len())?;
+    fn send(&self, buffer: &[u8], connection: L::Guard<'_>) -> Result {
+        let mut connection = self.check_peer_buffer_is_sufficient(connection, buffer.len())?;
 
         let len = buffer.len() as u32;
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Rw.into(),
             len: len.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
-        connection_info.tx_cnt += len;
+        connection.info.tx_cnt += len;
+        drop(connection);
+
         self.send_packet_to_queue(&header, buffer)
     }
 
-    fn check_peer_buffer_is_sufficient(
+    fn check_peer_buffer_is_sufficient<'a>(
         &self,
-        connection_info: &mut ConnectionInfo,
+        mut connection: L::Guard<'a>,
         buffer_len: usize,
-    ) -> Result {
-        if connection_info.peer_free() as usize >= buffer_len {
-            Ok(())
+    ) -> Result<L::Guard<'a>> {
+        if connection.info.peer_free() as usize >= buffer_len {
+            Ok(connection)
         } else {
             // Request an update of the cached peer credit, if we haven't already done so, and tell
             // the caller to try again later.
-            if !connection_info.has_pending_credit_request {
-                self.request_credit(connection_info)?;
-                connection_info.has_pending_credit_request = true;
+            if !connection.info.has_pending_credit_request {
+                connection.info.has_pending_credit_request = true;
+                self.request_credit(connection)?;
             }
             Err(SocketError::InsufficientBufferSpaceInPeer.into())
         }
     }
 
     /// Tells the peer how much buffer space we have to receive data.
-    fn credit_update(&self, connection_info: &ConnectionInfo) -> Result {
+    fn credit_update(&self, connection: L::Guard<'_>) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::CreditUpdate.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
+        drop(connection);
         self.send_packet_to_queue(&header, &[])
     }
 
@@ -545,16 +587,13 @@ pub trait VirtIOSocketManager: Send {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown_with_hints(
-        &self,
-        connection_info: &ConnectionInfo,
-        hints: StreamShutdown,
-    ) -> Result {
+    fn shutdown_with_hints(&self, connection: L::Guard<'_>, hints: StreamShutdown) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Shutdown.into(),
             flags: hints.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
+        drop(connection);
         self.send_packet_to_queue(&header, &[])
     }
 
@@ -564,19 +603,17 @@ pub trait VirtIOSocketManager: Send {
     /// This returns as soon as the request is sent; you should wait until `poll` returns a
     /// `VsockEventType::Disconnected` event if you want to know that the peer has acknowledged the
     /// shutdown.
-    fn shutdown(&self, connection_info: &ConnectionInfo) -> Result {
-        self.shutdown_with_hints(
-            connection_info,
-            StreamShutdown::SEND | StreamShutdown::RECEIVE,
-        )
+    fn shutdown(&self, connection: L::Guard<'_>) -> Result {
+        self.shutdown_with_hints(connection, StreamShutdown::SEND | StreamShutdown::RECEIVE)
     }
 
     /// Forcibly closes the connection without waiting for the peer.
-    fn force_close(&self, connection_info: &ConnectionInfo) -> Result {
+    fn force_close(&self, connection: L::Guard<'_>) -> Result {
         let header = VirtioVsockHdr {
             op: VirtioVsockOp::Rst.into(),
-            ..connection_info.new_header(self.local_cid())
+            ..connection.info.new_header(self.local_cid())
         };
+        drop(connection);
         self.send_packet_to_queue(&header, &[])?;
         Ok(())
     }

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -375,13 +375,10 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocket<H, T, RX_BU
     fn send_packet_to_tx_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
         let _len = if buffer.is_empty() {
             self.tx
-                .add_notify_wait_pop(&[header.as_bytes()], &mut [], &mut self.transport)?
+                .add_notify_wait_pop(&[header.as_bytes()], &mut [], &self.transport)?
         } else {
-            self.tx.add_notify_wait_pop(
-                &[header.as_bytes(), buffer],
-                &mut [],
-                &mut self.transport,
-            )?
+            self.tx
+                .add_notify_wait_pop(&[header.as_bytes(), buffer], &mut [], &self.transport)?
         };
         Ok(())
     }
@@ -415,7 +412,7 @@ impl<H: Hal, T: Transport, const RX_BUFFER_SIZE: usize> VirtIOSocketManager
         &mut self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        self.rx.poll(&mut self.transport, |buffer| {
+        self.rx.poll(&self.transport, |buffer| {
             let (header, body) = read_header_and_body(buffer)?;
             VsockEvent::from_header(&header).and_then(|event| handler(event, body))
         })
@@ -452,10 +449,10 @@ impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketManager for VirtIOSocketDevic
     fn send_packet_to_queue(&mut self, header: &VirtioVsockHdr, buffer: &[u8]) -> Result {
         if buffer.is_empty() {
             self.rx
-                .wait_pop_add_notify(&[header.as_bytes()], &mut self.transport)?
+                .wait_pop_add_notify(&[header.as_bytes()], &self.transport)?
         } else {
             self.rx
-                .wait_pop_add_notify(&[header.as_bytes(), buffer], &mut self.transport)?
+                .wait_pop_add_notify(&[header.as_bytes(), buffer], &self.transport)?
         }
         Ok(())
     }
@@ -463,7 +460,7 @@ impl<H: DeviceHal, T: DeviceTransport> VirtIOSocketManager for VirtIOSocketDevic
         &mut self,
         handler: impl FnOnce(VsockEvent, &[u8]) -> Result<Option<VsockEvent>>,
     ) -> Result<Option<VsockEvent>> {
-        self.tx.poll(&mut self.transport, |buffer| {
+        self.tx.poll(&self.transport, |buffer| {
             let (header, body) = read_header_and_body(buffer)?;
             VsockEvent::from_header(&header).and_then(|event| handler(event, body))
         })

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -506,6 +506,15 @@ pub trait VirtIOSocketManager<L: LockFactory>: Send {
         self.send_packet_to_queue(&header, &[])
     }
 
+    /// Rejects an incoming connection request from a peer by sending a reset.
+    fn reject(&self, info: ConnectionInfo) -> Result {
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Rst.into(),
+            ..info.new_header(self.local_cid())
+        };
+        self.send_packet_to_queue(&header, &[])
+    }
+
     /// Requests the peer to send us a credit update for the given connection.
     fn request_credit(&self, connection: Arc<L::Lock<Connection>>) -> Result {
         let connection = connection.lock();

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -529,31 +529,9 @@ pub trait VirtIOSocketManager<L: LockFactory>: Send {
 
     /// Sends the buffer to the destination.
     fn send(&self, buffer: &[u8], connection: Arc<L::Lock<Connection>>) -> Result {
-        let connection = self.check_peer_buffer_is_sufficient(connection, buffer.len())?;
-
-        let mut connection = connection.lock();
         let len = buffer.len() as u32;
-        let header = VirtioVsockHdr {
-            op: VirtioVsockOp::Rw.into(),
-            len: len.into(),
-            ..connection.info.new_header(self.local_cid())
-        };
-        connection.info.tx_cnt += len;
-        drop(connection);
-
-        self.send_packet_to_queue(&header, buffer)
-    }
-
-    fn check_peer_buffer_is_sufficient<'a>(
-        &self,
-        connection: Arc<L::Lock<Connection>>,
-        buffer_len: usize,
-    ) -> Result<Arc<L::Lock<Connection>>> {
         let mut connection_guard = connection.lock();
-        if connection_guard.info.peer_free() as usize >= buffer_len {
-            drop(connection_guard);
-            Ok(connection)
-        } else {
+        if (connection_guard.info.peer_free() as usize) < buffer.len() {
             // Request an update of the cached peer credit, if we haven't already done so, and tell
             // the caller to try again later.
             if !connection_guard.info.has_pending_credit_request {
@@ -561,8 +539,18 @@ pub trait VirtIOSocketManager<L: LockFactory>: Send {
                 drop(connection_guard);
                 self.request_credit(connection)?;
             }
-            Err(SocketError::InsufficientBufferSpaceInPeer.into())
+            return Err(SocketError::InsufficientBufferSpaceInPeer.into());
         }
+
+        let header = VirtioVsockHdr {
+            op: VirtioVsockOp::Rw.into(),
+            len: len.into(),
+            ..connection_guard.info.new_header(self.local_cid())
+        };
+        connection_guard.info.tx_cnt += len;
+        drop(connection_guard);
+
+        self.send_packet_to_queue(&header, buffer)
     }
 
     /// Tells the peer how much buffer space we have to receive data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,32 @@ impl From<alloc::string::FromUtf8Error> for Error {
     }
 }
 
+/// A generic lock trait which protects a value of type `T`.
+pub trait Lock<T>: Send + Sync {
+    /// A guard which releases the lock when dropped.
+    type Guard<'a>: core::ops::DerefMut<Target = T>
+    where
+        Self: 'a,
+        T: 'a;
+
+    /// Wraps the given value in a new lock.
+    fn new(data: T) -> Self;
+
+    /// Locks the value and returns a mutable guard to it.
+    fn lock(&self) -> Self::Guard<'_>;
+
+    /// Returns a raw pointer to the protected value.
+    fn data_ptr(&self) -> *mut T;
+}
+
+/// A generic factory trait allowing one lock type parameter to wrap multiple distinct inner types.
+pub trait LockFactory {
+    /// The lock type used to protect values of type `T`.
+    type Lock<T>: Lock<T>
+    where
+        T: Send;
+}
+
 /// Align `size` up to a page.
 fn align_up(size: usize) -> usize {
     (size + PAGE_SIZE) & !(PAGE_SIZE - 1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,43 @@ pub trait LockFactory {
         T: Send;
 }
 
+/// A [`Lock`] backed by a [`spin::mutex::SpinMutex`].
+#[cfg(feature = "spin")]
+pub struct SpinLock<T>(spin::mutex::SpinMutex<T>);
+
+#[cfg(feature = "spin")]
+impl<T: Send> Lock<T> for SpinLock<T> {
+    type Guard<'a>
+        = spin::mutex::SpinMutexGuard<'a, T>
+    where
+        Self: 'a,
+        T: 'a;
+
+    fn new(data: T) -> Self {
+        Self(spin::mutex::SpinMutex::new(data))
+    }
+
+    fn lock(&self) -> Self::Guard<'_> {
+        self.0.lock()
+    }
+
+    fn data_ptr(&self) -> *mut T {
+        self.0.as_mut_ptr()
+    }
+}
+
+/// A [`LockFactory`] which produces [`SpinLock`]s.
+#[cfg(feature = "spin")]
+pub struct SpinLockFactory;
+
+#[cfg(feature = "spin")]
+impl LockFactory for SpinLockFactory {
+    type Lock<T>
+        = SpinLock<T>
+    where
+        T: Send;
+}
+
 /// Align `size` up to a page.
 fn align_up(size: usize) -> usize {
     (size + PAGE_SIZE) & !(PAGE_SIZE - 1)

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -308,7 +308,7 @@ impl<H: Hal, const SIZE: usize> VirtQueue<H, SIZE> {
         &mut self,
         inputs: &'a [&'a [u8]],
         outputs: &'a mut [&'a mut [u8]],
-        transport: &mut impl Transport,
+        transport: &impl Transport,
     ) -> Result<u32> {
         // SAFETY: We don't return until the same token has been popped, so the buffers remain
         // valid and are not otherwise accessed until then.
@@ -669,7 +669,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
     pub fn wait_pop_add_notify(
         &mut self,
         inputs: &[&[u8]],
-        transport: &mut impl DeviceTransport,
+        transport: &impl DeviceTransport,
     ) -> Result<()> {
         #[cfg(feature = "alloc")]
         {
@@ -715,7 +715,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
 
     pub fn poll<T>(
         &mut self,
-        transport: &mut impl DeviceTransport,
+        transport: &impl DeviceTransport,
         handler: impl FnOnce(&[u8]) -> Result<Option<T>>,
     ) -> Result<Option<T>> {
         #[cfg(feature = "alloc")]

--- a/src/queue/owning.rs
+++ b/src/queue/owning.rs
@@ -54,7 +54,7 @@ impl<H: Hal, const SIZE: usize, const BUFFER_SIZE: usize> OwningQueue<H, SIZE, B
     ///
     /// The buffer must not currently be in the RX queue, and no other references to it must exist
     /// between when this method is called and when it is popped from the queue.
-    unsafe fn add_buffer_to_queue(&mut self, index: u16, transport: &mut impl Transport) -> Result {
+    unsafe fn add_buffer_to_queue(&mut self, index: u16, transport: &impl Transport) -> Result {
         // SAFETY: The buffer lives as long as the queue, and the caller guarantees that it's not
         // currently in the queue or referred to anywhere else until it is popped.
         unsafe {
@@ -106,7 +106,7 @@ impl<H: Hal, const SIZE: usize, const BUFFER_SIZE: usize> OwningQueue<H, SIZE, B
     /// avoided.
     pub fn poll<T>(
         &mut self,
-        transport: &mut impl Transport,
+        transport: &impl Transport,
         handler: impl FnOnce(&[u8]) -> Result<Option<T>>,
     ) -> Result<Option<T>> {
         let Some((buffer, token)) = self.pop()? else {

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -47,7 +47,7 @@ impl<C: FromBytes + Immutable + IntoBytes> DeviceTransport for FakeTransport<C> 
         [addrs.descriptors, addrs.driver_area, addrs.device_area]
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         self.state.lock().unwrap().queues[queue as usize]
             .device_notified
             .store(true, Ordering::SeqCst);
@@ -71,7 +71,7 @@ impl<C: FromBytes + Immutable + IntoBytes> Transport for FakeTransport<C> {
         self.max_queue_size
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         self.state.lock().unwrap().queues[queue as usize]
             .notified
             .store(true, Ordering::SeqCst);

--- a/src/transport/fake.rs
+++ b/src/transport/fake.rs
@@ -28,7 +28,7 @@ pub struct FakeTransport<C> {
     pub state: Arc<Mutex<State<C>>>,
 }
 
-impl<C: FromBytes + Immutable + IntoBytes> DeviceTransport for FakeTransport<C> {
+impl<C: FromBytes + Immutable + IntoBytes + Send> DeviceTransport for FakeTransport<C> {
     fn get_client_id(&self) -> u16 {
         0
     }
@@ -54,7 +54,7 @@ impl<C: FromBytes + Immutable + IntoBytes> DeviceTransport for FakeTransport<C> 
     }
 }
 
-impl<C: FromBytes + Immutable + IntoBytes> Transport for FakeTransport<C> {
+impl<C: FromBytes + Immutable + IntoBytes + Send> Transport for FakeTransport<C> {
     fn device_type(&self) -> DeviceType {
         self.device_type
     }

--- a/src/transport/mmio.rs
+++ b/src/transport/mmio.rs
@@ -353,7 +353,7 @@ impl Transport for MmioTransport {
         }
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         // SAFETY: `self.header` points to a valid VirtIO MMIO region.
         unsafe {
             volwrite!(self.header, queue_notify, queue.into());

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,7 +16,7 @@ pub use some::SomeTransport;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// A VirtIO device-side transport layer.
-pub trait DeviceTransport {
+pub trait DeviceTransport: Send {
     /// Gets the client VM ID
     fn get_client_id(&self) -> u16;
 
@@ -36,7 +36,7 @@ pub trait DeviceTransport {
 }
 
 /// A VirtIO transport layer.
-pub trait Transport {
+pub trait Transport: Send {
     /// Gets the device type.
     fn device_type(&self) -> DeviceType;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,7 +32,7 @@ pub trait DeviceTransport: Send {
     fn queue_get(&mut self, queue: u16) -> [PhysAddr; 3];
 
     /// Notifies the given queue on the device.
-    fn notify(&mut self, queue: u16);
+    fn notify(&self, queue: u16);
 }
 
 /// A VirtIO transport layer.
@@ -50,7 +50,7 @@ pub trait Transport: Send {
     fn max_queue_size(&mut self, queue: u16) -> u32;
 
     /// Notifies the given queue on the device.
-    fn notify(&mut self, queue: u16);
+    fn notify(&self, queue: u16);
 
     /// Gets the device status.
     fn get_status(&self) -> DeviceStatus;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,7 +16,7 @@ pub use some::SomeTransport;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 /// A VirtIO device-side transport layer.
-pub trait DeviceTransport: Send {
+pub trait DeviceTransport: Send + Sync {
     /// Gets the client VM ID
     fn get_client_id(&self) -> u16;
 
@@ -36,7 +36,7 @@ pub trait DeviceTransport: Send {
 }
 
 /// A VirtIO transport layer.
-pub trait Transport: Send {
+pub trait Transport: Send + Sync {
     /// Gets the device type.
     fn device_type(&self) -> DeviceType;
 

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -247,7 +247,7 @@ impl Transport for PciTransport {
         }
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         // SAFETY: The common config and notify region pointers are valid and we checked in
         // `get_bar_region` that they were aligned.
         unsafe {

--- a/src/transport/pci.rs
+++ b/src/transport/pci.rs
@@ -79,6 +79,10 @@ pub fn virtio_device_type(device_function_info: &DeviceFunctionInfo) -> Option<D
     None
 }
 
+/// Number of queues whose `queue_notify_off` is cached so `notify` avoids a racy select-then-read.
+/// Queues beyond this fall back to reading the offset on each call.
+pub(crate) const NOTIFY_OFFSET_CACHE_LEN: usize = 16;
+
 /// PCI transport for VirtIO.
 ///
 /// Ref: 4.1 Virtio Over PCI Bus
@@ -92,6 +96,8 @@ pub struct PciTransport {
     /// The start of the queue notification region within some BAR.
     notify_region: NonNull<[WriteOnly<u16>]>,
     notify_off_multiplier: u32,
+    /// Cached `queue_notify_off` values indexed by queue, populated in `queue_set`.
+    notify_offsets: [u16; NOTIFY_OFFSET_CACHE_LEN],
     /// The ISR status register within some BAR.
     isr_status: NonNull<Volatile<u8>>,
     /// The VirtIO device-specific configuration within some BAR.
@@ -200,6 +206,7 @@ impl PciTransport {
             common_cfg,
             notify_region,
             notify_off_multiplier,
+            notify_offsets: [0; NOTIFY_OFFSET_CACHE_LEN],
             isr_status,
             config_space,
         })
@@ -248,15 +255,21 @@ impl Transport for PciTransport {
     }
 
     fn notify(&self, queue: u16) {
-        // SAFETY: The common config and notify region pointers are valid and we checked in
-        // `get_bar_region` that they were aligned.
-        unsafe {
-            volwrite!(self.common_cfg, queue_select, queue);
-            // TODO: Consider caching this somewhere (per queue).
-            let queue_notify_off = volread!(self.common_cfg, queue_notify_off);
+        let queue_notify_off = match self.notify_offsets.get(usize::from(queue)) {
+            Some(&offset) => offset,
+            // SAFETY: The common config pointer is valid and we checked in `get_bar_region` that it
+            // was aligned.
+            None => unsafe {
+                volwrite!(self.common_cfg, queue_select, queue);
+                volread!(self.common_cfg, queue_notify_off)
+            },
+        };
 
-            let offset_bytes = usize::from(queue_notify_off) * self.notify_off_multiplier as usize;
-            let index = offset_bytes / size_of::<u16>();
+        let offset_bytes = usize::from(queue_notify_off) * self.notify_off_multiplier as usize;
+        let index = offset_bytes / size_of::<u16>();
+        // SAFETY: The notify region pointer is valid and we checked in `get_bar_region` that it was
+        // aligned.
+        unsafe {
             (&raw mut (*self.notify_region.as_ptr())[index]).vwrite(queue);
         }
     }
@@ -301,6 +314,12 @@ impl Transport for PciTransport {
             volwrite!(self.common_cfg, queue_driver, driver_area as u64);
             volwrite!(self.common_cfg, queue_device, device_area as u64);
             volwrite!(self.common_cfg, queue_enable, 1);
+        }
+
+        if let Some(slot) = self.notify_offsets.get_mut(usize::from(queue)) {
+            // SAFETY: The common config pointer is valid and aligned, and `queue` is still selected
+            // from the writes above.
+            *slot = unsafe { volread!(self.common_cfg, queue_notify_off) };
         }
     }
 

--- a/src/transport/some.rs
+++ b/src/transport/some.rs
@@ -64,7 +64,7 @@ impl Transport for SomeTransport {
         }
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         match self {
             Self::Mmio(mmio) => mmio.notify(queue),
             Self::Pci(pci) => pci.notify(queue),

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -183,7 +183,7 @@ impl Transport for HypPciTransport {
         queue_size.into()
     }
 
-    fn notify(&mut self, queue: u16) {
+    fn notify(&self, queue: u16) {
         configwrite!(self.common_cfg, queue_select, queue);
         // TODO: Consider caching this somewhere (per queue).
         let queue_notify_off: u16 = configread!(self.common_cfg, queue_notify_off);

--- a/src/transport/x86_64.rs
+++ b/src/transport/x86_64.rs
@@ -8,8 +8,8 @@ use super::{
         bus::{ConfigurationAccess, DeviceFunction, PciRoot, PCI_CAP_ID_VNDR},
         device_type, CommonCfg, VirtioCapabilityInfo, VirtioPciError, CAP_BAR_OFFSET,
         CAP_BAR_OFFSET_OFFSET, CAP_LENGTH_OFFSET, CAP_NOTIFY_OFF_MULTIPLIER_OFFSET,
-        VIRTIO_PCI_CAP_COMMON_CFG, VIRTIO_PCI_CAP_DEVICE_CFG, VIRTIO_PCI_CAP_ISR_CFG,
-        VIRTIO_PCI_CAP_NOTIFY_CFG, VIRTIO_VENDOR_ID,
+        NOTIFY_OFFSET_CACHE_LEN, VIRTIO_PCI_CAP_COMMON_CFG, VIRTIO_PCI_CAP_DEVICE_CFG,
+        VIRTIO_PCI_CAP_ISR_CFG, VIRTIO_PCI_CAP_NOTIFY_CFG, VIRTIO_VENDOR_ID,
     },
     DeviceStatus, DeviceType, Transport,
 };
@@ -41,6 +41,8 @@ pub struct HypPciTransport {
     /// The start of the queue notification region within some BAR.
     notify_region: HypIoRegion,
     notify_off_multiplier: u32,
+    /// Cached `queue_notify_off` values indexed by queue, populated in `queue_set`.
+    notify_offsets: [u16; NOTIFY_OFFSET_CACHE_LEN],
     /// The ISR status register within some BAR.
     isr_status: HypIoRegion,
     /// The VirtIO device-specific configuration within some BAR.
@@ -147,6 +149,7 @@ impl HypPciTransport {
             common_cfg,
             notify_region,
             notify_off_multiplier,
+            notify_offsets: [0; NOTIFY_OFFSET_CACHE_LEN],
             isr_status,
             config_space,
         })
@@ -184,9 +187,13 @@ impl Transport for HypPciTransport {
     }
 
     fn notify(&self, queue: u16) {
-        configwrite!(self.common_cfg, queue_select, queue);
-        // TODO: Consider caching this somewhere (per queue).
-        let queue_notify_off: u16 = configread!(self.common_cfg, queue_notify_off);
+        let queue_notify_off = match self.notify_offsets.get(usize::from(queue)) {
+            Some(&offset) => offset,
+            None => {
+                configwrite!(self.common_cfg, queue_select, queue);
+                configread!(self.common_cfg, queue_notify_off)
+            }
+        };
 
         let offset_bytes = usize::from(queue_notify_off) * self.notify_off_multiplier as usize;
         self.notify_region.write(offset_bytes, queue);
@@ -223,6 +230,10 @@ impl Transport for HypPciTransport {
         configwrite!(self.common_cfg, queue_driver, driver_area as u64);
         configwrite!(self.common_cfg, queue_device, device_area as u64);
         configwrite!(self.common_cfg, queue_enable, 1u16);
+
+        if let Some(slot) = self.notify_offsets.get_mut(usize::from(queue)) {
+            *slot = configread!(self.common_cfg, queue_notify_off);
+        }
     }
 
     fn queue_unset(&mut self, _queue: u16) {


### PR DESCRIPTION
Locking refactor concurrency and correctness fixes:

- Reject ConnectionRequest to a non-listening port; send RST after `driver.poll` returns so the rx queue lock isn't held.
- Reserve peer credit under one lock in `send()` to avoid `tx_cnt` double-count.
- Roll back `has_pending_credit_request` when `request_credit` fails.
- Take `*mut Self` in `ack_interrupt` instead of `&self` to avoid UB from a `&self`-derived write.
- Cache `queue_notify_off` so `notify` avoids a racy select-then-read.
- Send RST before removing the connection in `recv`/`force_close`, so a failed close can be retried.

Fixes #34
