### PR TITLE
Check DeviceVirtQueue SIZE parameter matches Transport::max_queue_size exactly

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -629,7 +629,7 @@ impl<H: DeviceHal, const SIZE: usize> DeviceVirtQueue<H, SIZE> {
         #[allow(clippy::let_unit_value)]
         let _ = Self::SIZE_OK;
 
-        if transport.max_queue_size(idx) < SIZE as u32 {
+        if transport.max_queue_size(idx) != SIZE as u32 {
             return Err(Error::InvalidParam);
         }
         let client_id = transport.get_client_id();


### PR DESCRIPTION
DeviceVirtQueue was modeled after the existing (driver-side) VirtQueue which checks if the virtqueue SIZE parameter is less than the max size reported by the transport for the given queue. This is sensible for the driver-side since it gets to decide how many descriptors are in each virtqueue (subject to max sizes imposed by the transport) and all driver-side clients in this crate make the queue size a const. However, there is an asymmetry between the device/driver because the device has to use whatever size queue the driver chooses at runtime. This commit changes the check in DeviceVirtQueue to check that the SIZE parameter exactly matches what the driver reports, because if the driver decides to use a smaller queue size the DeviceVirtQueue methods will just do the wrong thing. This initial commit removes the possibility of misusing DeviceVirtQueue when using different queue sizes to prepare for future commits that will make the queue sizes configurable on the driver side. Fixes the bug reported in #38 but doesn't fully address the issue (i.e. make it a runtime value).