### PR TITLE
Make vsock queue size configurable at compile-time

### DIFF
--- a/src/device/socket/connectionmanager.rs
+++ b/src/device/socket/connectionmanager.rs
@@ -30,7 +30,7 @@ const DEFAULT_PER_CONNECTION_BUFFER_CAPACITY: u32 = 1024;
 /// use virtio_drivers_and_devices::device::socket::{VirtIOSocket, VsockAddr, VsockConnectionManager};
 ///
 /// # fn example<HalImpl: Hal, T: Transport, L: LockFactory>(transport: T) -> Result<(), Error> {
-/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _, L>::new(transport)?);
+/// let mut socket = VsockConnectionManager::new(VirtIOSocket::<HalImpl, _, L, 256>::new(transport)?);
 ///
 /// // Start a thread to call `socket.poll()` and handle events.
 ///
@@ -50,12 +50,13 @@ pub struct VsockConnectionManager<
     H: Hal,
     T: Transport,
     L: LockFactory,
+    const QUEUE_SIZE: usize,
     const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
->(VsockConnectionManagerCommon<VirtIOSocket<H, T, L, RX_BUFFER_SIZE>, L>);
+>(VsockConnectionManagerCommon<VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>, L>);
 
 /// A high level interface for VirtIO socket (vsock) devices.
-pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: LockFactory>(
-    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T, L>, L>,
+pub struct VsockDeviceConnectionManager<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize>(
+    VsockConnectionManagerCommon<VirtIOSocketDevice<H, T, L, QUEUE_SIZE>, L>,
 );
 
 /// A trait defining shared behavior for VirtIO socket devices and drivers.
@@ -163,18 +164,18 @@ impl Connection {
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
-    VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const QUEUE_SIZE: usize, const RX_BUFFER_SIZE: usize>
+    VsockConnectionManager<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>
 {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
-    pub fn new(driver: VirtIOSocket<H, T, L, RX_BUFFER_SIZE>) -> Self {
+    pub fn new(driver: VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>) -> Self {
         Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
     }
 
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver, with
     /// the given per-connection buffer capacity.
     pub fn new_with_capacity(
-        driver: VirtIOSocket<H, T, L, RX_BUFFER_SIZE>,
+        driver: VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>,
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
@@ -312,16 +313,16 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionManager<H, T, L> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize> VsockDeviceConnectionManager<H, T, L, QUEUE_SIZE> {
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver.
-    pub fn new(driver: VirtIOSocketDevice<H, T, L>) -> Self {
+    pub fn new(driver: VirtIOSocketDevice<H, T, L, QUEUE_SIZE>) -> Self {
         Self::new_with_capacity(driver, DEFAULT_PER_CONNECTION_BUFFER_CAPACITY)
     }
 
     /// Construct a new connection manager wrapping the given low-level VirtIO socket driver, with
     /// the given per-connection buffer capacity.
     pub fn new_with_capacity(
-        driver: VirtIOSocketDevice<H, T, L>,
+        driver: VirtIOSocketDevice<H, T, L, QUEUE_SIZE>,
         per_connection_buffer_capacity: u32,
     ) -> Self {
         Self(VsockConnectionManagerCommon {
@@ -420,8 +421,8 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockDeviceConnectionMana
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockManager
-    for VsockConnectionManager<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const QUEUE_SIZE: usize, const RX_BUFFER_SIZE: usize> VsockManager
+    for VsockConnectionManager<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>
 {
     fn accept(&self, c: Connection) -> Result {
         Self::accept(self, c)
@@ -463,12 +464,12 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VsockMan
         let vsock_driver_ptr = (&raw const self.0.driver).cast_mut();
         // SAFETY: This function's safety requirements ensure that `self` points to a valid
         // VsockConnectionManager so this gives a valid pointer to the field.
-        unsafe { VirtIOSocket::<H, T, L, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
+        unsafe { VirtIOSocket::<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>::ack_interrupt(vsock_driver_ptr) }
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VsockManager
-    for VsockDeviceConnectionManager<H, T, L>
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize> VsockManager
+    for VsockDeviceConnectionManager<H, T, L, QUEUE_SIZE>
 {
     fn accept(&self, c: Connection) -> Result {
         Self::accept(self, c)

--- a/src/device/socket/vsock.rs
+++ b/src/device/socket/vsock.rs
@@ -22,7 +22,6 @@ pub(crate) const RX_QUEUE_IDX: u16 = 0;
 pub(crate) const TX_QUEUE_IDX: u16 = 1;
 const EVENT_QUEUE_IDX: u16 = 2;
 
-pub(crate) const QUEUE_SIZE: usize = 8;
 const SUPPORTED_FEATURES: Feature = Feature::RING_EVENT_IDX
     .union(Feature::RING_INDIRECT_DESC)
     .union(Feature::VERSION_1);
@@ -229,21 +228,22 @@ pub struct VirtIOSocket<
     H: Hal,
     T: Transport,
     L: LockFactory,
+    const QUEUE_SIZE: usize,
     const RX_BUFFER_SIZE: usize = DEFAULT_RX_BUFFER_SIZE,
 > {
     transport: T,
     /// Virtqueue to receive packets.
     rx: L::Lock<OwningQueue<H, QUEUE_SIZE, RX_BUFFER_SIZE>>,
-    tx: L::Lock<VirtQueue<H, { QUEUE_SIZE }>>,
+    tx: L::Lock<VirtQueue<H, QUEUE_SIZE>>,
     /// Virtqueue to receive events from the device.
-    event: L::Lock<VirtQueue<H, { QUEUE_SIZE }>>,
+    event: L::Lock<VirtQueue<H, QUEUE_SIZE>>,
     /// The guest_cid field contains the guest’s context ID, which uniquely identifies
     /// the device for its lifetime. The upper 32 bits of the CID are reserved and zeroed.
     guest_cid: u64,
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> Drop
-    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const QUEUE_SIZE: usize, const RX_BUFFER_SIZE: usize> Drop
+    for VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>
 {
     fn drop(&mut self) {
         // Clear any pointers pointing to DMA regions, so the device doesn't try to access them
@@ -254,8 +254,8 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> Drop
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
-    VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const QUEUE_SIZE: usize, const RX_BUFFER_SIZE: usize>
+    VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>
 {
     /// Create a new VirtIO Vsock driver.
     pub fn new(mut transport: T) -> Result<Self> {
@@ -418,8 +418,8 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize>
     }
 }
 
-impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSocketManager<L>
-    for VirtIOSocket<H, T, L, RX_BUFFER_SIZE>
+impl<H: Hal, T: Transport, L: LockFactory, const QUEUE_SIZE: usize, const RX_BUFFER_SIZE: usize> VirtIOSocketManager<L>
+    for VirtIOSocket<H, T, L, QUEUE_SIZE, RX_BUFFER_SIZE>
 {
     fn local_cid(&self) -> u64 {
         self.guest_cid()
@@ -439,14 +439,14 @@ impl<H: Hal, T: Transport, L: LockFactory, const RX_BUFFER_SIZE: usize> VirtIOSo
 }
 
 /// A low-level interface for a vsock device implementation
-pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport, L: LockFactory> {
+pub struct VirtIOSocketDevice<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize> {
     transport: T,
-    rx: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
-    tx: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
-    event: L::Lock<DeviceVirtQueue<H, { QUEUE_SIZE }>>,
+    rx: L::Lock<DeviceVirtQueue<H, QUEUE_SIZE>>,
+    tx: L::Lock<DeviceVirtQueue<H, QUEUE_SIZE>>,
+    event: L::Lock<DeviceVirtQueue<H, QUEUE_SIZE>>,
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketDevice<H, T, L> {
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize> VirtIOSocketDevice<H, T, L, QUEUE_SIZE> {
     /// Create a new VirtIO Vsock device.
     pub fn new(mut transport: T) -> Result<Self> {
         let rx = DeviceVirtQueue::new(&mut transport, RX_QUEUE_IDX)?;
@@ -461,8 +461,8 @@ impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketDevice<H, T, 
     }
 }
 
-impl<H: DeviceHal, T: DeviceTransport, L: LockFactory> VirtIOSocketManager<L>
-    for VirtIOSocketDevice<H, T, L>
+impl<H: DeviceHal, T: DeviceTransport, L: LockFactory, const QUEUE_SIZE: usize> VirtIOSocketManager<L>
+    for VirtIOSocketDevice<H, T, L, QUEUE_SIZE>
 {
     fn local_cid(&self) -> u64 {
         VMADDR_CID_HOST


### PR DESCRIPTION
Previously `const QUEUE_SIZE: usize = 8;` in vsock.rs determined the virtqueue size (number of descriptors) to be used by both the vsock device and driver clients. Different use-cases/transports may need more or fewer descriptors and this design did not allow configuring it. This commit removes that constant and instead bubbles up the QUEUE_SIZE parameters on the virtqueue struct fields in the vsock clients types up to VsockConnectionManager to allow making them configurable on a per-instance basis.